### PR TITLE
Feature/유저 상세 페이지 추가, 스타일링 변경

### DIFF
--- a/src/components/common/CustomForm/CustomForm.style.tsx
+++ b/src/components/common/CustomForm/CustomForm.style.tsx
@@ -9,20 +9,38 @@ export const GridWrap = styled.div<{ gridColumns: string }>`
 `;
 
 export const FormItem = styled(Form.Item)`
-  margin-left: 25px;
-  margin-bottom: 60px;
+  margin-bottom: 0;
   .ant-form-item-label > label {
-    font-size: 15px;
+    width: 120px;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
     font-weight: 600;
     color: #2c3e50;
+    background-color: rgb(243, 243, 243);
+    border: rgb(217, 217, 217) solid;
+    border-width: 1px;
+    border-radius: 0;
+    &:after {
+      display: none;
+    }
   }
 `;
 
 export const FormItemCheckbox = styled(Form.Item)``;
 
 export const StyledInput = styled(Input)`
-  border-radius: 7px;
+  border: rgb(217, 217, 217) solid;
+  border-width: 1px;
+  border-radius: 0;
+  display: inline-block;
+  transition: none;
+  appearance: none;
 `;
 
 export const StyledButton = styled(Button)`
+  border-radius: 0;
+  width: 80px;
 `;

--- a/src/components/common/CustomForm/CustomForm.style.tsx
+++ b/src/components/common/CustomForm/CustomForm.style.tsx
@@ -27,6 +27,26 @@ export const FormItem = styled(Form.Item)`
       display: none;
     }
   }
+  .ant-input-borderless:hover, 
+  .ant-input-borderless:focus, 
+  .ant-input-borderless-focused, 
+  .ant-input-borderless-disabled, 
+  .ant-input-borderless[disabled] {
+    border: rgb(217, 217, 217) solid;
+    border-width: 1px;
+  }
+
+  .ant-input-borderless-disabled, 
+  .ant-input-borderless[disabled] {
+    background: #f5f5f5;
+  }
+
+  .ant-form-item-explain-error{
+    position: absolute;
+    right: 12px;
+    z-index: 10;
+    top: 5px;
+  }
 `;
 
 export const FormItemCheckbox = styled(Form.Item)``;
@@ -36,8 +56,6 @@ export const StyledInput = styled(Input)`
   border-width: 1px;
   border-radius: 0;
   display: inline-block;
-  transition: none;
-  appearance: none;
 `;
 
 export const StyledButton = styled(Button)`

--- a/src/components/common/CustomForm/CustomForm.style.tsx
+++ b/src/components/common/CustomForm/CustomForm.style.tsx
@@ -2,6 +2,7 @@ import {
   Button, Form, Input,
 } from 'antd';
 import styled from 'styled-components';
+import { mobile } from 'utils/style/mediaQuery';
 
 export const GridWrap = styled.div<{ gridColumns: string }>`
   display: grid;
@@ -25,6 +26,18 @@ export const FormItem = styled(Form.Item)`
     border-radius: 0;
     &:after {
       display: none;
+      flex-basis: auto;
+    }
+  }
+  // 기본 설정된 반응형에 의한 디자인 깨짐 방지용
+  ${mobile}{
+    .ant-row .ant-form-item-label {
+      flex: 0 1 auto;
+      padding: 0;
+    }
+    .ant-row .ant-form-item-control {
+      flex: 1 1 auto;
+      padding: 0;
     }
   }
   .ant-input-borderless:hover, 
@@ -60,5 +73,5 @@ export const StyledInput = styled(Input)`
 
 export const StyledButton = styled(Button)`
   border-radius: 0;
-  width: 80px;
+  min-width: 80px;
 `;

--- a/src/components/common/CustomForm/CustomForm.style.tsx
+++ b/src/components/common/CustomForm/CustomForm.style.tsx
@@ -40,20 +40,7 @@ export const FormItem = styled(Form.Item)`
       padding: 0;
     }
   }
-  .ant-input-borderless:hover, 
-  .ant-input-borderless:focus, 
-  .ant-input-borderless-focused, 
-  .ant-input-borderless-disabled, 
-  .ant-input-borderless[disabled] {
-    border: rgb(217, 217, 217) solid;
-    border-width: 1px;
-  }
-
-  .ant-input-borderless-disabled, 
-  .ant-input-borderless[disabled] {
-    background: #f5f5f5;
-  }
-
+  
   .ant-form-item-explain-error{
     position: absolute;
     right: 12px;

--- a/src/components/common/CustomForm/index.tsx
+++ b/src/components/common/CustomForm/index.tsx
@@ -6,11 +6,14 @@ import {
 import { RoomOptionValue } from 'constant/roomOption';
 import React, { ReactNode } from 'react';
 import type { UploadFile } from 'antd/es/upload/interface';
+import { Rule } from 'antd/lib/form';
 import * as S from './CustomForm.style';
 
 interface InputProps {
   label: string;
   name: string;
+  disabled?: boolean;
+  rules?: Rule[];
 }
 
 interface TextAreaProps {
@@ -41,10 +44,12 @@ function GridRow({ children, gridColumns }: GridProps) {
   return <S.GridWrap gridColumns={gridColumns}>{children}</S.GridWrap>;
 }
 
-function CustomInput({ label, name }: InputProps) {
+function CustomInput({
+  label, name, disabled, rules,
+}: InputProps) {
   return (
-    <S.FormItem label={label} name={name}>
-      <S.StyledInput />
+    <S.FormItem label={label} name={name} rules={rules}>
+      <S.StyledInput disabled={disabled} bordered={false} />
     </S.FormItem>
   );
 }

--- a/src/components/common/CustomForm/index.tsx
+++ b/src/components/common/CustomForm/index.tsx
@@ -4,7 +4,7 @@ import {
   Button, Checkbox, Form, Input, Upload,
 } from 'antd';
 import { RoomOptionValue } from 'constant/roomOption';
-import React, { ReactNode } from 'react';
+import React, { ChangeEvent, ReactNode } from 'react';
 import type { UploadFile } from 'antd/es/upload/interface';
 import { Rule } from 'antd/lib/form';
 import * as S from './CustomForm.style';
@@ -14,6 +14,7 @@ interface InputProps {
   name: string;
   disabled?: boolean;
   rules?: Rule[];
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 
 interface TextAreaProps {
@@ -45,11 +46,11 @@ function GridRow({ children, gridColumns }: GridProps) {
 }
 
 function CustomInput({
-  label, name, disabled, rules,
+  label, name, disabled, rules, onChange,
 }: InputProps) {
   return (
     <S.FormItem label={label} name={name} rules={rules}>
-      <S.StyledInput disabled={disabled} bordered={false} />
+      <S.StyledInput disabled={disabled} bordered={false} onChange={onChange} />
     </S.FormItem>
   );
 }

--- a/src/components/common/CustomForm/index.tsx
+++ b/src/components/common/CustomForm/index.tsx
@@ -1,75 +1,67 @@
 /* eslint-disable react/require-default-props */
 import { UploadOutlined } from '@ant-design/icons';
 import {
-  Button, Checkbox, Form, Input, Upload,
+  Button, Checkbox, Form, Input, InputProps, Select, Upload,
 } from 'antd';
-import { RoomOptionValue } from 'constant/roomOption';
-import React, { ChangeEvent, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import type { UploadFile } from 'antd/es/upload/interface';
 import { Rule } from 'antd/lib/form';
 import * as S from './CustomForm.style';
-
-interface InputProps {
-  label: string;
-  name: string;
-  disabled?: boolean;
-  rules?: Rule[];
-  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
-}
-
-interface TextAreaProps {
-  label: string;
-  name: string;
-  maxLength?: number;
-}
 
 interface GridProps {
   children: ReactNode;
   gridColumns: string;
 }
 
-interface ButtonProps {
-  children: string;
-  danger?: boolean;
-  icon?: ReactNode;
-  onClick?: React.MouseEventHandler<HTMLButtonElement>;
-  htmlType?: 'button' | 'submit' | 'reset';
-}
-
-interface CheckboxProps {
-  res: RoomOptionValue;
-  children: ReactNode;
-}
-
 function GridRow({ children, gridColumns }: GridProps) {
   return <S.GridWrap gridColumns={gridColumns}>{children}</S.GridWrap>;
 }
 
+interface FormItemProps {
+  label: string;
+  name: string;
+  disabled?: boolean;
+  rules?: Rule[];
+}
+
 function CustomInput({
-  label, name, disabled, rules, onChange,
-}: InputProps) {
+  label, name, rules, disabled, ...args
+}: FormItemProps & InputProps) {
   return (
     <S.FormItem label={label} name={name} rules={rules}>
-      <S.StyledInput disabled={disabled} bordered={false} onChange={onChange} />
+      <S.StyledInput disabled={disabled} {...args} />
     </S.FormItem>
   );
 }
 
-function CusctomTextArea({ label, name, maxLength }: TextAreaProps) {
+interface TextAreaProps {
+  maxLength?: number;
+}
+
+function CusctomTextArea({
+  label, name, maxLength, disabled, rules,
+}: FormItemProps & TextAreaProps) {
   return (
-    <S.FormItem label={label} name={name}>
-      <Input.TextArea showCount maxLength={maxLength} />
+    <S.FormItem label={label} name={name} rules={rules}>
+      <Input.TextArea showCount maxLength={maxLength} disabled={disabled} />
     </S.FormItem>
   );
+}
+
+interface CheckboxProps {
+  name: string;
+  children: ReactNode;
+  disabled?: boolean;
 }
 
 function CustomCheckbox({
-  res,
+  name,
   children,
+  disabled,
 }: CheckboxProps) {
   return (
-    <S.FormItemCheckbox name={res.data} valuePropName="checked">
-      <Checkbox>
+    <S.FormItemCheckbox name={name} valuePropName="checked">
+      <Checkbox disabled={disabled}>
         {children}
       </Checkbox>
     </S.FormItemCheckbox>
@@ -87,6 +79,14 @@ function CustomUpload({ defaultFileList: fileList }: { defaultFileList: UploadFi
       <Button icon={<UploadOutlined />}>Upload</Button>
     </Upload>
   );
+}
+
+interface ButtonProps {
+  children: string;
+  danger?: boolean;
+  icon?: ReactNode;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  htmlType?: 'button' | 'submit' | 'reset';
 }
 
 function CustomButton({
@@ -111,6 +111,24 @@ function CustomButton({
   );
 }
 
+function CustomSelect({
+  options, label, name, rules, disabled,
+}: FormItemProps & {
+  options: Record<string, string>
+}) {
+  return (
+    <S.FormItem label={label} name={name} rules={rules}>
+      <Select disabled={disabled}>
+        {Object.entries(options).map(([key, val]) => (
+          <Select.Option value={Number.isNaN(key) ? key : Number(key)} key={key}>
+            {val}
+          </Select.Option>
+        ))}
+      </Select>
+    </S.FormItem>
+  );
+}
+
 const CustomForm = Object.assign(Form, {
   GridRow,
   Button: CustomButton,
@@ -118,6 +136,7 @@ const CustomForm = Object.assign(Form, {
   TextArea: CusctomTextArea,
   Upload: CustomUpload,
   Checkbox: CustomCheckbox,
+  Select: CustomSelect,
 });
 
 export default CustomForm;

--- a/src/components/common/SideNav/index.tsx
+++ b/src/components/common/SideNav/index.tsx
@@ -48,7 +48,7 @@ const items: MenuProps['items'] = [
 ];
 
 const SideNavConatiner = styled.nav`
-  height: 100vh;
+  height: 100%;
   width: 200px;
   overflow-y: auto;
 `;
@@ -65,7 +65,7 @@ function SideNav() {
         onClick={onClick}
         selectedKeys={[pathname]}
         defaultOpenKeys={['service', 'user']}
-        style={{ height: '100vh' }}
+        style={{ height: '100%' }}
         mode="inline"
         items={items}
       />

--- a/src/constant/roomOption.ts
+++ b/src/constant/roomOption.ts
@@ -65,9 +65,4 @@ const ROOM_OPTION = [
   },
 ] as const;
 
-export interface RoomOptionValue {
-  name: string;
-  data: string;
-}
-
-export { ROOM_OPTION };
+export default ROOM_OPTION;

--- a/src/constant/roomOption.ts
+++ b/src/constant/roomOption.ts
@@ -1,35 +1,3 @@
-const ROOM_INPUT = [
-  'name',
-  'room_type',
-  'management_fee',
-  'size',
-  'monthly_fee',
-  'charter_fee',
-  'latitude',
-  'longitude',
-  'deposit',
-  'floor',
-  'phone',
-  'address',
-  'description',
-  'opt_refrigerator',
-  'opt_closet',
-  'opt_tv',
-  'opt_microwave',
-  'opt_gas_range',
-  'opt_induction',
-  'opt_water_purifier',
-  'opt_air_conditioner',
-  'opt_washer',
-  'opt_bed',
-  'opt_desk',
-  'opt_shoe_closet',
-  'opt_electronic_door_locks',
-  'opt_bidet',
-  'opt_veranda',
-  'opt_elevator',
-] as const;
-
 const ROOM_OPTION = [
   {
     name: '냉장고',
@@ -102,4 +70,4 @@ export interface RoomOptionValue {
   data: string;
 }
 
-export { ROOM_OPTION, ROOM_INPUT };
+export { ROOM_OPTION };

--- a/src/constant/user.ts
+++ b/src/constant/user.ts
@@ -1,0 +1,8 @@
+const SELECT_OPTIONS = {
+  identity: {
+    0: '학생', 1: '대학원생', 2: '교수', 3: '교직원', 4: '졸업생', 5: '점주',
+  },
+  gender: { 0: '남성', 1: '여성' },
+};
+
+export default SELECT_OPTIONS;

--- a/src/layout/defaultLayout/defaultLayout.style.tsx
+++ b/src/layout/defaultLayout/defaultLayout.style.tsx
@@ -8,6 +8,6 @@ export const LayoutContainer = styled.div`
 `;
 
 export const Main = styled.main`
-  width: 100%;
+  width: 1000px;
   padding: 12px;
 `;

--- a/src/pages/Services/Room/DetailForm.tsx
+++ b/src/pages/Services/Room/DetailForm.tsx
@@ -31,27 +31,33 @@ export default function DetailForm() {
       form={form}
       fields={defaultValueArr}
     >
-      <CustomForm.GridRow gridColumns="1.5fr 1fr 1fr 1fr">
-        <CustomForm.Input label="방이름" name="name" />
+      <Divider orientation="left">기본 정보</Divider>
+      <CustomForm.Input label="방이름" name="name" />
+      <CustomForm.GridRow gridColumns="1fr 1fr">
         <CustomForm.Input label="방종류" name="room_type" />
-        <CustomForm.Input label="관리비" name="management_fee" />
         <CustomForm.Input label="방크기" name="size" />
       </CustomForm.GridRow>
-      <CustomForm.GridRow gridColumns="1.5fr 1fr 1fr 1fr">
-        <CustomForm.Input label="월세" name="monthly_fee" />
-        <CustomForm.Input label="전세" name="charter_fee" />
+
+      <CustomForm.Input label="월세" name="monthly_fee" />
+      <CustomForm.Input label="전세" name="charter_fee" />
+      <CustomForm.GridRow gridColumns="1fr 1fr">
+        <CustomForm.Input label="관리비" name="management_fee" />
+        <CustomForm.Input label="보증금" name="deposit" />
+      </CustomForm.GridRow>
+
+      <CustomForm.GridRow gridColumns="1fr 1fr">
         <CustomForm.Input label="위도" name="latitude" />
         <CustomForm.Input label="경도" name="longitude" />
       </CustomForm.GridRow>
-      <CustomForm.GridRow gridColumns="1fr 1fr 1.5fr 2fr">
-        <CustomForm.Input label="보증금" name="deposit" />
+
+      <CustomForm.GridRow gridColumns="1fr 1fr">
         <CustomForm.Input label="층수" name="floor" />
         <CustomForm.Input label="전화번호" name="phone" />
-        <CustomForm.Input label="주소" name="address" />
       </CustomForm.GridRow>
+      <CustomForm.Input label="주소" name="address" />
       <CustomForm.TextArea label="설명" name="description" maxLength={200} />
-      <Divider orientation="left">옵션</Divider>
 
+      <Divider orientation="left" style={{ marginTop: '40px' }}>옵션</Divider>
       <S.CheckboxWrap>
         {ROOM_OPTION.map(
           (optionData) => roomRes && (

--- a/src/pages/Services/Room/DetailForm.tsx
+++ b/src/pages/Services/Room/DetailForm.tsx
@@ -2,7 +2,7 @@ import { DeleteOutlined, UploadOutlined } from '@ant-design/icons';
 import { Divider } from 'antd';
 import { UploadFile } from 'antd/es/upload/interface';
 import CustomForm from 'components/common/CustomForm';
-import { ROOM_OPTION } from 'constant/roomOption';
+import ROOM_OPTION from 'constant/roomOption';
 import { useParams } from 'react-router-dom';
 import { useGetRoomQuery } from 'store/api/room';
 import getDefaultValueArr from 'utils/ts/getDefaultValueArr';
@@ -59,16 +59,14 @@ export default function DetailForm() {
 
       <Divider orientation="left" style={{ marginTop: '40px' }}>옵션</Divider>
       <S.CheckboxWrap>
-        {ROOM_OPTION.map(
-          (optionData) => roomRes && (
+        {ROOM_OPTION.map((optionData) => roomRes && (
           <CustomForm.Checkbox
             key={optionData.name}
-            res={optionData}
+            name={optionData.data}
           >
             {optionData.name}
           </CustomForm.Checkbox>
-          ),
-        )}
+        ))}
       </S.CheckboxWrap>
 
       <Divider orientation="left">사진</Divider>

--- a/src/pages/Services/Room/DetailForm.tsx
+++ b/src/pages/Services/Room/DetailForm.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
 import { DeleteOutlined, UploadOutlined } from '@ant-design/icons';
 import { Divider } from 'antd';
 import { UploadFile } from 'antd/es/upload/interface';
 import CustomForm from 'components/common/CustomForm';
-import { ROOM_INPUT, ROOM_OPTION } from 'constant/roomOption';
+import { ROOM_OPTION } from 'constant/roomOption';
 import { useParams } from 'react-router-dom';
 import { useGetRoomQuery } from 'store/api/room';
+import getDefaultValueArr from 'utils/ts/getDefaultValueArr';
 import useRoomMutation from './useRoomMutation';
 import * as S from './RoomDetail.style';
 
@@ -13,8 +13,8 @@ export default function DetailForm() {
   const { id } = useParams();
   const { data: roomRes } = useGetRoomQuery(Number(id));
   const { updateRoomDetail } = useRoomMutation(Number(id));
-
   const [form] = CustomForm.useForm();
+  const defaultValueArr = getDefaultValueArr(roomRes);
 
   const imageList: UploadFile[] | undefined = roomRes?.image_urls?.map(
     (res, index) => ({
@@ -22,13 +22,6 @@ export default function DetailForm() {
       name: res,
       status: 'done',
       url: res,
-    }),
-  );
-
-  const defaultValueArr = ROOM_INPUT.map(
-    (inputData) => ({
-      name: [inputData],
-      value: roomRes && roomRes[inputData],
     }),
   );
 

--- a/src/pages/Services/Room/RoomDetail.style.tsx
+++ b/src/pages/Services/Room/RoomDetail.style.tsx
@@ -16,7 +16,7 @@ export const SubHeading = styled.div`
 `;
 
 export const FormWrap = styled.div`
-  padding: 50px 120px 60px 20px;
+  padding: 20px 120px 60px 20px;
   .ant-form-item-label > label {
     font-size: 15px;
     font-weight: 600;
@@ -48,8 +48,8 @@ export const FormItem = styled(Form.Item)`
 
 export const CheckboxWrap = styled.div`
   margin-left: 25px;
-  margin-bottom: 50px;
-  margin-top: 40px;
+  margin-bottom: 20px;
+  margin-top: 10px;
   display: -webkit-inline-box;
   flex-wrap: wrap;
   width: 50vw;

--- a/src/pages/Services/Room/RoomDetail.tsx
+++ b/src/pages/Services/Room/RoomDetail.tsx
@@ -1,4 +1,4 @@
-import { Divider, Spin } from 'antd';
+import { Spin } from 'antd';
 import React, { Suspense } from 'react';
 import DetailForm from './DetailForm';
 import * as S from './RoomDetail.style';
@@ -8,7 +8,6 @@ export default function RoomDetail() {
     <S.Container>
       <S.Heading>Room Detail</S.Heading>
       <S.SubHeading>Home / Room / RoomDetail</S.SubHeading>
-      <Divider />
       <S.FormWrap>
         <Suspense fallback={<Spin />}>
           <DetailForm />

--- a/src/pages/UserManage/User/UserDetail.style.tsx
+++ b/src/pages/UserManage/User/UserDetail.style.tsx
@@ -39,3 +39,10 @@ export const FormWrapper = styled.div`
     margin-left: 0;
   }
 `;
+
+export const ButtonWrap = styled.div`
+  margin-top: 20px;
+  margin-left: 15px;
+  display: flex;
+  justify-content: flex-end;
+`;

--- a/src/pages/UserManage/User/UserDetail.style.tsx
+++ b/src/pages/UserManage/User/UserDetail.style.tsx
@@ -1,9 +1,41 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
-  
+  font-family: 'Avenir', 'Helvetica', 'Arial', 'sans-serif';
 `;
 
-export const Heading = styled.h1`
-  
+export const Heading = styled.div`
+  color: #2c3e50;
+  font-size: 28px;
+`;
+
+export const SubHeading = styled.div`
+  font-size: 13px;
+  padding: 12px 0;
+`;
+
+export const FormWrapper = styled.div`
+  padding: 50px 120px 60px 20px;
+  .ant-form-item-label > label {
+    font-size: 15px;
+    font-weight: 600;
+    color: #2c3e50;
+  }
+
+  .ant-divider-with-text {
+    font-size: 15px;
+    font-weight: 600;
+    color: #2c3e50;
+  }
+
+  .ant-checkbox + span {
+    padding: 10px 39px 10px 10px;
+    font-size: 15px;
+    font-weight: 500;
+    color: #2c3e50;
+  }
+
+  .ant-checkbox-wrapper + .ant-checkbox-wrapper {
+    margin-left: 0;
+  }
 `;

--- a/src/pages/UserManage/User/UserDetail.style.tsx
+++ b/src/pages/UserManage/User/UserDetail.style.tsx
@@ -15,7 +15,7 @@ export const SubHeading = styled.div`
 `;
 
 export const FormWrapper = styled.div`
-  padding: 50px 120px 60px 20px;
+  padding: 10px 120px 60px 20px;
   .ant-form-item-label > label {
     font-size: 15px;
     font-weight: 600;

--- a/src/pages/UserManage/User/UserDetail.tsx
+++ b/src/pages/UserManage/User/UserDetail.tsx
@@ -38,7 +38,7 @@ function UserDetail() {
               </CustomForm.GridRow>
               <CustomForm.Input label="학교 계정" name="portal_account" disabled />
               <CustomForm.Input label="이름" name="name" />
-              <CustomForm.GridRow gridColumns="1fr 80px">
+              <CustomForm.GridRow gridColumns="1fr auto">
                 <CustomForm.Input label="닉네임" name="nickname" onChange={handleNicknameChange} rules={[{ validator }]} />
                 <CustomForm.Button onClick={checkDuplicateNickname}>중복확인</CustomForm.Button>
               </CustomForm.GridRow>

--- a/src/pages/UserManage/User/UserDetail.tsx
+++ b/src/pages/UserManage/User/UserDetail.tsx
@@ -29,6 +29,8 @@ function UserDetail() {
               onFinish={updateUser}
             >
               <Divider orientation="left">기본 정보</Divider>
+              <CustomForm.Checkbox name="is_authed" disabled>이메일 인증 완료 여부</CustomForm.Checkbox>
+
               <CustomForm.Input label="ID" name="id" disabled />
               <CustomForm.Input label="학교 계정" name="portal_account" disabled />
 
@@ -47,6 +49,7 @@ function UserDetail() {
                 <CustomForm.Input label="학번" name="student_number" />
                 <CustomForm.Input label="전공" name="major" disabled />
               </CustomForm.GridRow>
+              <CustomForm.Select label="성별" name="gender" options={{ 0: '남성', 1: '여성' }} />
               <CustomForm.Button htmlType="submit">정보 수정</CustomForm.Button>
             </CustomForm>
           </S.FormWrapper>

--- a/src/pages/UserManage/User/UserDetail.tsx
+++ b/src/pages/UserManage/User/UserDetail.tsx
@@ -1,6 +1,7 @@
+import { Divider } from 'antd';
 import CustomForm from 'components/common/CustomForm';
 import { useParams } from 'react-router-dom';
-import { useGetUserQuery } from 'store/api/user';
+import { useGetNicknameCheckMutation, useGetUserQuery, useUpdateUserMutation } from 'store/api/user';
 import getDefaultValueArr from 'utils/ts/getDefaultValueArr';
 import * as S from './UserDetail.style';
 
@@ -9,6 +10,15 @@ function UserDetail() {
   const { data: userData } = useGetUserQuery(Number(id));
   const [form] = CustomForm.useForm();
   const defaultValueArr = getDefaultValueArr(userData);
+  const [checkNickname] = useGetNicknameCheckMutation();
+  const [updateUserRequest] = useUpdateUserMutation();
+
+  const checkDuplicateNickname = () => checkNickname(form.getFieldValue('nickname')).then(() => Promise.resolve()).catch(() => Promise.reject());
+  const updateUser = (formData: typeof userData) => {
+    if (formData) {
+      updateUserRequest(formData);
+    }
+  };
 
   return (
     <S.Container>
@@ -18,9 +28,29 @@ function UserDetail() {
           <S.SubHeading>
             {`User Management / User Detail / ${userData.name}`}
           </S.SubHeading>
-          <CustomForm form={form} fields={defaultValueArr}>
-            <CustomForm.Input label="이름" name="name" />
-          </CustomForm>
+          <Divider />
+          <S.FormWrapper>
+            <CustomForm
+              form={form}
+              fields={defaultValueArr}
+              onFinish={updateUser}
+            >
+              <CustomForm.GridRow gridColumns="1fr 1fr">
+                <CustomForm.Input label="ID" name="id" disabled />
+                <CustomForm.Input label="학교 계정" name="portal_account" disabled />
+              </CustomForm.GridRow>
+              <CustomForm.GridRow gridColumns="50% 1fr 80px">
+                <CustomForm.Input label="이름" name="name" />
+                <CustomForm.Input label="닉네임" name="nickname" rules={[{ validator: checkDuplicateNickname }]} />
+                <CustomForm.Button onClick={() => checkNickname('재히히')}>중복확인</CustomForm.Button>
+              </CustomForm.GridRow>
+              <CustomForm.GridRow gridColumns="1fr 1fr">
+                <CustomForm.Input label="학번" name="student_number" />
+                <CustomForm.Input label="전공" name="major" disabled />
+              </CustomForm.GridRow>
+              <CustomForm.Button htmlType="submit">정보 수정</CustomForm.Button>
+            </CustomForm>
+          </S.FormWrapper>
         </>
       )}
     </S.Container>

--- a/src/pages/UserManage/User/UserDetail.tsx
+++ b/src/pages/UserManage/User/UserDetail.tsx
@@ -1,14 +1,28 @@
+import CustomForm from 'components/common/CustomForm';
 import { useParams } from 'react-router-dom';
+import { useGetUserQuery } from 'store/api/user';
+import getDefaultValueArr from 'utils/ts/getDefaultValueArr';
 import * as S from './UserDetail.style';
 
 function UserDetail() {
   const { id } = useParams();
+  const { data: userData } = useGetUserQuery(Number(id));
+  const [form] = CustomForm.useForm();
+  const defaultValueArr = getDefaultValueArr(userData);
+
   return (
     <S.Container>
-      <S.Heading>
-        User:
-        {id}
-      </S.Heading>
+      {userData && (
+        <>
+          <S.Heading>User Detail</S.Heading>
+          <S.SubHeading>
+            {`User Management / User Detail / ${userData.name}`}
+          </S.SubHeading>
+          <CustomForm form={form} fields={defaultValueArr}>
+            <CustomForm.Input label="이름" name="name" />
+          </CustomForm>
+        </>
+      )}
     </S.Container>
   );
 }

--- a/src/pages/UserManage/User/UserDetail.tsx
+++ b/src/pages/UserManage/User/UserDetail.tsx
@@ -1,5 +1,7 @@
+import { DeleteOutlined, UploadOutlined } from '@ant-design/icons';
 import { Divider } from 'antd';
 import CustomForm from 'components/common/CustomForm';
+import SELECT_OPTIONS from 'constant/user';
 import { useParams } from 'react-router-dom';
 import { useGetUserQuery } from 'store/api/user';
 import useNicknameCheck from './hooks/useNicknameCheck';
@@ -30,27 +32,32 @@ function UserDetail() {
             >
               <Divider orientation="left">기본 정보</Divider>
               <CustomForm.Checkbox name="is_authed" disabled>이메일 인증 완료 여부</CustomForm.Checkbox>
-
-              <CustomForm.Input label="ID" name="id" disabled />
+              <CustomForm.GridRow gridColumns="1fr 1fr">
+                <CustomForm.Input label="ID" name="id" disabled />
+                <CustomForm.Input label="최종 로그인 시간" name="last_logged_at" disabled />
+              </CustomForm.GridRow>
               <CustomForm.Input label="학교 계정" name="portal_account" disabled />
-
               <CustomForm.Input label="이름" name="name" />
               <CustomForm.GridRow gridColumns="1fr 80px">
-                <CustomForm.Input
-                  label="닉네임"
-                  name="nickname"
-                  onChange={changeNickname}
-                  rules={[{ validator: nicknameValidator }]}
-                />
+                <CustomForm.Input label="닉네임" name="nickname" onChange={changeNickname} rules={[{ validator: nicknameValidator }]} />
                 <CustomForm.Button onClick={checkDuplicateNickname}>중복확인</CustomForm.Button>
               </CustomForm.GridRow>
-
               <CustomForm.GridRow gridColumns="1fr 1fr">
                 <CustomForm.Input label="학번" name="student_number" />
                 <CustomForm.Input label="전공" name="major" disabled />
               </CustomForm.GridRow>
-              <CustomForm.Select label="성별" name="gender" options={{ 0: '남성', 1: '여성' }} />
-              <CustomForm.Button htmlType="submit">정보 수정</CustomForm.Button>
+              <CustomForm.Select label="성별" name="gender" options={SELECT_OPTIONS.gender} />
+              <CustomForm.Input label="전화번호" name="phone_number" />
+              <CustomForm.Select label="구분" name="identity" options={SELECT_OPTIONS.identity} />
+
+              <S.ButtonWrap>
+                <CustomForm.Button icon={<UploadOutlined />} htmlType="submit">
+                  정보 수정
+                </CustomForm.Button>
+                <CustomForm.Button danger icon={<DeleteOutlined />}>
+                  유저 삭제
+                </CustomForm.Button>
+              </S.ButtonWrap>
             </CustomForm>
           </S.FormWrapper>
         </>

--- a/src/pages/UserManage/User/UserDetail.tsx
+++ b/src/pages/UserManage/User/UserDetail.tsx
@@ -12,7 +12,7 @@ function UserDetail() {
   const { id } = useParams();
   const { data: userData } = useGetUserQuery(Number(id));
   const [form] = CustomForm.useForm();
-  const { changeNickname, checkDuplicateNickname, nicknameValidator } = useNicknameCheck(form);
+  const { handleNicknameChange, checkDuplicateNickname, validator } = useNicknameCheck(form);
   const { updateUser } = useUserMutation();
 
   return (
@@ -39,7 +39,7 @@ function UserDetail() {
               <CustomForm.Input label="학교 계정" name="portal_account" disabled />
               <CustomForm.Input label="이름" name="name" />
               <CustomForm.GridRow gridColumns="1fr 80px">
-                <CustomForm.Input label="닉네임" name="nickname" onChange={changeNickname} rules={[{ validator: nicknameValidator }]} />
+                <CustomForm.Input label="닉네임" name="nickname" onChange={handleNicknameChange} rules={[{ validator }]} />
                 <CustomForm.Button onClick={checkDuplicateNickname}>중복확인</CustomForm.Button>
               </CustomForm.GridRow>
               <CustomForm.GridRow gridColumns="1fr 1fr">

--- a/src/pages/UserManage/User/UserDetail.tsx
+++ b/src/pages/UserManage/User/UserDetail.tsx
@@ -1,24 +1,17 @@
 import { Divider } from 'antd';
 import CustomForm from 'components/common/CustomForm';
 import { useParams } from 'react-router-dom';
-import { useGetNicknameCheckMutation, useGetUserQuery, useUpdateUserMutation } from 'store/api/user';
-import getDefaultValueArr from 'utils/ts/getDefaultValueArr';
+import { useGetUserQuery } from 'store/api/user';
+import useNicknameCheck from './hooks/useNicknameCheck';
+import useUserMutation from './hooks/useUserMutation';
 import * as S from './UserDetail.style';
 
 function UserDetail() {
   const { id } = useParams();
   const { data: userData } = useGetUserQuery(Number(id));
   const [form] = CustomForm.useForm();
-  const defaultValueArr = getDefaultValueArr(userData);
-  const [checkNickname] = useGetNicknameCheckMutation();
-  const [updateUserRequest] = useUpdateUserMutation();
-
-  const checkDuplicateNickname = () => checkNickname(form.getFieldValue('nickname')).then(() => Promise.resolve()).catch(() => Promise.reject());
-  const updateUser = (formData: typeof userData) => {
-    if (formData) {
-      updateUserRequest(formData);
-    }
-  };
+  const { changeNickname, checkDuplicateNickname, nicknameValidator } = useNicknameCheck(form);
+  const { updateUser } = useUserMutation();
 
   return (
     <S.Container>
@@ -32,18 +25,24 @@ function UserDetail() {
           <S.FormWrapper>
             <CustomForm
               form={form}
-              fields={defaultValueArr}
+              initialValues={userData}
               onFinish={updateUser}
             >
-              <CustomForm.GridRow gridColumns="1fr 1fr">
-                <CustomForm.Input label="ID" name="id" disabled />
-                <CustomForm.Input label="학교 계정" name="portal_account" disabled />
+              <Divider orientation="left">기본 정보</Divider>
+              <CustomForm.Input label="ID" name="id" disabled />
+              <CustomForm.Input label="학교 계정" name="portal_account" disabled />
+
+              <CustomForm.Input label="이름" name="name" />
+              <CustomForm.GridRow gridColumns="1fr 80px">
+                <CustomForm.Input
+                  label="닉네임"
+                  name="nickname"
+                  onChange={changeNickname}
+                  rules={[{ validator: nicknameValidator }]}
+                />
+                <CustomForm.Button onClick={checkDuplicateNickname}>중복확인</CustomForm.Button>
               </CustomForm.GridRow>
-              <CustomForm.GridRow gridColumns="50% 1fr 80px">
-                <CustomForm.Input label="이름" name="name" />
-                <CustomForm.Input label="닉네임" name="nickname" rules={[{ validator: checkDuplicateNickname }]} />
-                <CustomForm.Button onClick={() => checkNickname('재히히')}>중복확인</CustomForm.Button>
-              </CustomForm.GridRow>
+
               <CustomForm.GridRow gridColumns="1fr 1fr">
                 <CustomForm.Input label="학번" name="student_number" />
                 <CustomForm.Input label="전공" name="major" disabled />

--- a/src/pages/UserManage/User/hooks/useNicknameCheck.ts
+++ b/src/pages/UserManage/User/hooks/useNicknameCheck.ts
@@ -7,7 +7,7 @@ export default function useNicknameCheck(form: FormInstance) {
   const [nicknameChecked, setNicknameChecked] = useState(true);
   const [checkNickname] = useGetNicknameCheckMutation();
 
-  const changeNickname = () => {
+  const handleNicknameChange = () => {
     setNicknameChecked(false);
   };
 
@@ -24,11 +24,11 @@ export default function useNicknameCheck(form: FormInstance) {
       });
   };
 
-  const nicknameValidator = () => (nicknameChecked ? Promise.resolve() : Promise.reject(new Error('닉네임 중복을 확인해주세요')));
+  const validator = () => (nicknameChecked ? Promise.resolve() : Promise.reject(new Error('닉네임 중복을 확인해주세요')));
 
   useEffect(() => {
     form.validateFields(['nickname']);
   }, [nicknameChecked, form]);
 
-  return { changeNickname, checkDuplicateNickname, nicknameValidator };
+  return { handleNicknameChange, checkDuplicateNickname, validator };
 }

--- a/src/pages/UserManage/User/hooks/useNicknameCheck.ts
+++ b/src/pages/UserManage/User/hooks/useNicknameCheck.ts
@@ -18,8 +18,8 @@ export default function useNicknameCheck(form: FormInstance) {
         makeToast('success', '사용 가능한 닉네임입니다.');
         setNicknameChecked(true);
       })
-      .catch(() => {
-        makeToast('error', '이미 존재하는 닉네임입니다.');
+      .catch(({ data }) => {
+        makeToast('error', data.error.message);
         setNicknameChecked(false);
       });
   };

--- a/src/pages/UserManage/User/hooks/useNicknameCheck.ts
+++ b/src/pages/UserManage/User/hooks/useNicknameCheck.ts
@@ -1,0 +1,34 @@
+import { FormInstance } from 'antd';
+import { useEffect, useState } from 'react';
+import { useGetNicknameCheckMutation } from 'store/api/user';
+import makeToast from 'utils/ts/makeToast';
+
+export default function useNicknameCheck(form: FormInstance) {
+  const [nicknameChecked, setNicknameChecked] = useState(true);
+  const [checkNickname] = useGetNicknameCheckMutation();
+
+  const changeNickname = () => {
+    setNicknameChecked(false);
+  };
+
+  const checkDuplicateNickname = () => {
+    checkNickname(form.getFieldValue('nickname'))
+      .unwrap()
+      .then(() => {
+        makeToast('success', '사용 가능한 닉네임입니다.');
+        setNicknameChecked(true);
+      })
+      .catch(() => {
+        makeToast('error', '이미 존재하는 닉네임입니다.');
+        setNicknameChecked(false);
+      });
+  };
+
+  const nicknameValidator = () => (nicknameChecked ? Promise.resolve() : Promise.reject(new Error('닉네임 중복을 확인해주세요')));
+
+  useEffect(() => {
+    form.validateFields(['nickname']);
+  }, [nicknameChecked, form]);
+
+  return { changeNickname, checkDuplicateNickname, nicknameValidator };
+}

--- a/src/pages/UserManage/User/hooks/useUserMutation.ts
+++ b/src/pages/UserManage/User/hooks/useUserMutation.ts
@@ -1,0 +1,14 @@
+import { UserDetail } from 'model/user.model';
+import { useUpdateUserMutation } from 'store/api/user';
+
+export default function useUserMutation() {
+  const [updateUserRequest] = useUpdateUserMutation();
+
+  const updateUser = (formData: UserDetail) => {
+    if (formData) {
+      updateUserRequest(formData);
+    }
+  };
+
+  return { updateUser };
+}

--- a/src/pages/UserManage/User/hooks/useUserMutation.ts
+++ b/src/pages/UserManage/User/hooks/useUserMutation.ts
@@ -1,12 +1,23 @@
 import { UserDetail } from 'model/user.model';
+import { useNavigate } from 'react-router-dom';
 import { useUpdateUserMutation } from 'store/api/user';
+import makeToast from 'utils/ts/makeToast';
 
 export default function useUserMutation() {
   const [updateUserRequest] = useUpdateUserMutation();
+  const navigate = useNavigate();
 
   const updateUser = (formData: UserDetail) => {
     if (formData) {
-      updateUserRequest(formData);
+      updateUserRequest(formData)
+        .unwrap()
+        .then(() => {
+          makeToast('success', '정보 수정이 완료되었습니다.');
+          navigate(-1);
+        })
+        .catch(({ data }) => {
+          makeToast('error', data.error.message);
+        });
     }
   };
 

--- a/src/pages/UserManage/User/hooks/useUserMutation.ts
+++ b/src/pages/UserManage/User/hooks/useUserMutation.ts
@@ -8,17 +8,15 @@ export default function useUserMutation() {
   const navigate = useNavigate();
 
   const updateUser = (formData: UserDetail) => {
-    if (formData) {
-      updateUserRequest(formData)
-        .unwrap()
-        .then(() => {
-          makeToast('success', '정보 수정이 완료되었습니다.');
-          navigate(-1);
-        })
-        .catch(({ data }) => {
-          makeToast('error', data.error.message);
-        });
-    }
+    updateUserRequest(formData)
+      .unwrap()
+      .then(() => {
+        makeToast('success', '정보 수정이 완료되었습니다.');
+        navigate(-1);
+      })
+      .catch(({ data }) => {
+        makeToast('error', data.error.message);
+      });
   };
 
   return { updateUser };

--- a/src/store/api/user/index.ts
+++ b/src/store/api/user/index.ts
@@ -48,7 +48,7 @@ export const userApi = createApi({
       query: (nickname) => `user/check/nickname/${nickname}`,
     }),
 
-    updateUser: builder.mutation<void, UserDetail>({
+    updateUser: builder.mutation<void, Pick<UserDetail, 'id'> & Partial<UserDetail>>({
       query(data) {
         const { id, ...body } = data;
         return {

--- a/src/store/api/user/index.ts
+++ b/src/store/api/user/index.ts
@@ -1,14 +1,14 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { RootState } from 'store';
 import { API_PATH } from 'constant';
-import { UsersResponse, UserTableHead } from 'model/user.model';
+import { UserDetail, UsersResponse, UserTableHead } from 'model/user.model';
 
 export const userApi = createApi({
   reducerPath: 'user',
   // 초기화용 태그
-  tagTypes: ['users'],
+  tagTypes: ['users', 'user'],
   baseQuery: fetchBaseQuery({
-    baseUrl: `${API_PATH}/admin`,
+    baseUrl: `${API_PATH}`,
     prepareHeaders: (headers, { getState }) => {
       const { token } = (getState() as RootState).auth;
       if (token) {
@@ -20,7 +20,7 @@ export const userApi = createApi({
   endpoints: (builder) => ({
     // builder.query<리턴 타입, 갱신 인자(여기선 page)>
     getUserList: builder.query<{ userList: UserTableHead[], totalPage: number }, number>({
-      query: (page) => `users/?page=${page}`,
+      query: (page) => `admin/users/?page=${page}`,
       providesTags: ['users'],
       transformResponse:
         (usersResponse: UsersResponse): { userList: UserTableHead[], totalPage: number } => {
@@ -41,7 +41,30 @@ export const userApi = createApi({
           };
         },
     }),
+
+    getUser: builder.query<UserDetail, number>({
+      query: (id) => `admin/users/${id}`,
+      providesTags: (result, error, id) => [{ type: 'user', id }],
+    }),
+
+    getNicknameCheck: builder.mutation<{ success: string }, string>({
+      query: (nickname) => `user/check/nickname/${nickname}`,
+    }),
+
+    updateUser: builder.mutation<void, UserDetail>({
+      query(data) {
+        const { id, ...body } = data;
+        return {
+          url: `admin/users/${id}`,
+          method: 'PUT',
+          body,
+        };
+      },
+      invalidatesTags: (result, error, { id }) => [{ type: 'user', id }],
+    }),
   }),
 });
 
-export const { useGetUserListQuery } = userApi;
+export const {
+  useGetUserListQuery, useGetUserQuery, useGetNicknameCheckMutation, useUpdateUserMutation,
+} = userApi;

--- a/src/store/api/user/index.ts
+++ b/src/store/api/user/index.ts
@@ -19,7 +19,9 @@ export const userApi = createApi({
   endpoints: (builder) => ({
     getUserList: builder.query<{ userList: UserTableHead[], totalPage: number }, number>({
       query: (page) => `admin/users/?page=${page}`,
-      providesTags: ['users'],
+      providesTags: (result) => (result
+        ? [...result.userList.map((user) => ({ type: 'user' as const, id: user.id })), { type: 'users', id: 'LIST' }]
+        : [{ type: 'users', id: 'LIST' }]),
       transformResponse:
         (usersResponse: UsersResponse): { userList: UserTableHead[], totalPage: number } => {
           const tableData = usersResponse.items.map(({
@@ -57,7 +59,7 @@ export const userApi = createApi({
           body,
         };
       },
-      invalidatesTags: (result, error, { id }) => ['users', { type: 'user', id }],
+      invalidatesTags: (result, error, { id }) => [{ type: 'user', id }],
     }),
   }),
 });

--- a/src/store/api/user/index.ts
+++ b/src/store/api/user/index.ts
@@ -5,7 +5,6 @@ import { UserDetail, UsersResponse, UserTableHead } from 'model/user.model';
 
 export const userApi = createApi({
   reducerPath: 'user',
-  // 초기화용 태그
   tagTypes: ['users', 'user'],
   baseQuery: fetchBaseQuery({
     baseUrl: `${API_PATH}`,
@@ -18,13 +17,11 @@ export const userApi = createApi({
     },
   }),
   endpoints: (builder) => ({
-    // builder.query<리턴 타입, 갱신 인자(여기선 page)>
     getUserList: builder.query<{ userList: UserTableHead[], totalPage: number }, number>({
       query: (page) => `admin/users/?page=${page}`,
       providesTags: ['users'],
       transformResponse:
         (usersResponse: UsersResponse): { userList: UserTableHead[], totalPage: number } => {
-          // 테이블에 보여주고 싶은 값들만 꺼내기
           const tableData = usersResponse.items.map(({
             id, portal_account, identity, nickname, name,
           }) => ({
@@ -60,7 +57,7 @@ export const userApi = createApi({
           body,
         };
       },
-      invalidatesTags: (result, error, { id }) => [{ type: 'user', id }],
+      invalidatesTags: (result, error, { id }) => ['users', { type: 'user', id }],
     }),
   }),
 });

--- a/src/utils/ts/getDefaultValueArr.ts
+++ b/src/utils/ts/getDefaultValueArr.ts
@@ -1,0 +1,8 @@
+export default function getDefaultValueArr(obj: Object | undefined) {
+  return obj
+    ? Object.entries(obj).map(([key, value]) => ({
+      name: key,
+      value,
+    }))
+    : undefined;
+}


### PR DESCRIPTION
## 유저 상세 페이지
- form에 포함된 닉네임의 중복을 확인하기 위한 `useNicknameCheck` hook 추가
- 기존 CustomForm에 `rules`, `disabled` 등 `Item`에 포함될 props를 추가
  - 그 외 `Input`에 종속된 기본 props를 받을 수 있게끔 수정
- 기존 Form의 초기값을 관리하기 위해 사용하던 `fields` 를 `initialValues` 로 변경하여 `checkNickname` Mutation 실행으로 인한 상태 초기화를 방지
- `CustomForm.Select` 추가. `{[name]: value}`구조의 `options`을 props로 받습니다.
- `/pages/UserManage/User/UserDetail.tsx` 위주로 리뷰 부탁드립니다.

## Form 스타일링 변경
- 전체적인 스타일링 수정 (table형태)
- 모바일 반응형 시 스타일링이 의도치 않게 깨지는 오류 수정
- `sideNav`의 `height`이 `100vh`로 고정되어 더 늘어나지 않는 문제 수정
- `defaultLayout`의 `width`를 고정시켜 일정한 너비를 유지하게 수정

<img width="1488" alt="image" src="https://user-images.githubusercontent.com/50780281/204122762-ff641366-933f-4dbf-96f1-6440340f826b.png">
<img width="1488" alt="image" src="https://user-images.githubusercontent.com/50780281/204122767-c6c98a28-1268-49a7-b576-cfa863330f9f.png">
