### PR TITLE
Feature/API 변경 적용 및 테이블 너비 추가

### DIFF
--- a/src/components/common/CustomTable/index.tsx
+++ b/src/components/common/CustomTable/index.tsx
@@ -34,18 +34,22 @@ interface Props<TableData> {
     total: number;
     onChange: (idx: number) => void;
   };
+  columnSize?: number[];
 }
 
-function CustomTable<TableData extends DefaultTableData>({ data, pagination }: Props<TableData>) {
+function CustomTable<TableData extends DefaultTableData>(
+  { data, pagination, columnSize }: Props<TableData>,
+) {
   const navigate = useNavigate();
 
   const getColumns = (): ColumnsType<TableData> => {
     const columnKeys = Object.keys(data[0]);
 
-    return columnKeys.map((key) => ({
+    return columnKeys.map((key, idx) => ({
       title: TITLE_MAPPER[key] || key.toUpperCase(),
       dataIndex: key,
       key,
+      width: columnSize && columnSize[idx] ? `${columnSize[idx]}%` : 'auto',
     }));
   };
 

--- a/src/components/common/CustomTable/index.tsx
+++ b/src/components/common/CustomTable/index.tsx
@@ -36,9 +36,7 @@ interface Props<TableData> {
   };
 }
 
-function CustomTable<TableData extends DefaultTableData>({
-  data, pagination,
-}: Props<TableData>) {
+function CustomTable<TableData extends DefaultTableData>({ data, pagination }: Props<TableData>) {
   const navigate = useNavigate();
 
   const getColumns = (): ColumnsType<TableData> => {
@@ -62,9 +60,7 @@ function CustomTable<TableData extends DefaultTableData>({
             navigate(`${record.id}`);
           },
         })}
-        pagination={
-          pagination?.total ? false : { position: ['bottomRight'] }
-        }
+        pagination={pagination ? false : { position: ['bottomRight'] }}
       />
       {pagination && (
         <Pagination

--- a/src/constant/index.ts
+++ b/src/constant/index.ts
@@ -14,4 +14,6 @@ export const TITLE_MAPPER: Record<string, string> = {
   room_type: '방 종류',
   management_fee: '관리비',
   size: '평수',
+  major: '학과',
+  student_number: '학번',
 };

--- a/src/model/common.model.ts
+++ b/src/model/common.model.ts
@@ -1,0 +1,6 @@
+export interface ListResponsePagination {
+  totalPage: number;
+  totalCount: number;
+  currentCount: number;
+  currentPage: number;
+}

--- a/src/model/common.model.ts
+++ b/src/model/common.model.ts
@@ -1,4 +1,4 @@
-export interface ListResponsePagination {
+export interface ListPagination {
   total_page: number;
   total_count: number;
   current_count: number;

--- a/src/model/common.model.ts
+++ b/src/model/common.model.ts
@@ -1,6 +1,6 @@
 export interface ListResponsePagination {
-  totalPage: number;
-  totalCount: number;
-  currentCount: number;
-  currentPage: number;
+  total_page: number;
+  total_count: number;
+  current_count: number;
+  current_page: number;
 }

--- a/src/model/room.model.ts
+++ b/src/model/room.model.ts
@@ -1,3 +1,5 @@
+import { ListResponsePagination } from './common.model';
+
 export interface RoomResponse {
   address: string;
   charter_fee: string;
@@ -40,8 +42,7 @@ export interface RoomTableHead {
   charter_fee: number | null;
 }
 
-export interface RoomsResponse {
-  totalPage: number;
+export interface RoomsResponse extends ListResponsePagination {
   lands: RoomTableHead[];
 }
 

--- a/src/model/room.model.ts
+++ b/src/model/room.model.ts
@@ -1,4 +1,4 @@
-import { ListResponsePagination } from './common.model';
+import { ListPagination } from './common.model';
 
 export interface RoomResponse {
   address: string;
@@ -42,7 +42,7 @@ export interface RoomTableHead {
   charter_fee: number | null;
 }
 
-export interface RoomsResponse extends ListResponsePagination {
+export interface RoomsResponse extends ListPagination {
   lands: RoomTableHead[];
 }
 

--- a/src/model/user.model.ts
+++ b/src/model/user.model.ts
@@ -1,4 +1,4 @@
-import { ListResponsePagination } from './common.model';
+import { ListPagination } from './common.model';
 
 /**
  * @param {number} identity 0: 학생, 1: 대학원생, 2: 교수, 3: 교직원, 4: 졸업생, 5: 점주
@@ -49,7 +49,7 @@ export interface UserTableHead {
   student_number: string | null;
 }
 
-export interface UsersResponse extends ListResponsePagination {
+export interface UsersResponse extends ListPagination {
   users: UserListData[];
 }
 

--- a/src/model/user.model.ts
+++ b/src/model/user.model.ts
@@ -41,12 +41,22 @@ export interface UserDetail {
 export interface UserTableHead {
   id: number;
   portal_account: string;
-  identity: number;
-  nickname: string | null;
+  nickname: string;
   name: string | null;
+  major: string | null;
+  student_number: string | null;
 }
 
 export interface UsersResponse {
   totalPage: number;
-  items: UserDetail[];
+  users: UserListData[];
+}
+
+export interface UserListData {
+  id: number;
+  portal_account: string;
+  nickname: string;
+  name: string | null;
+  major: string | null;
+  student_number: string | null;
 }

--- a/src/model/user.model.ts
+++ b/src/model/user.model.ts
@@ -1,3 +1,5 @@
+import { ListResponsePagination } from './common.model';
+
 /**
  * @param {number} identity 0: 학생, 1: 대학원생, 2: 교수, 3: 교직원, 4: 졸업생, 5: 점주
  * @param {number} gender 0: 남자, 1: 여자
@@ -47,8 +49,7 @@ export interface UserTableHead {
   student_number: string | null;
 }
 
-export interface UsersResponse {
-  totalPage: number;
+export interface UsersResponse extends ListResponsePagination {
   users: UserListData[];
 }
 

--- a/src/pages/Services/Room/RoomDetail.style.tsx
+++ b/src/pages/Services/Room/RoomDetail.style.tsx
@@ -17,12 +17,7 @@ export const SubHeading = styled.div`
 
 export const FormWrap = styled.div`
   padding: 20px 120px 60px 20px;
-  .ant-form-item-label > label {
-    font-size: 15px;
-    font-weight: 600;
-    color: #2c3e50;
-  }
-
+  
   .ant-divider-with-text {
     font-size: 15px;
     font-weight: 600;

--- a/src/pages/Services/Room/RoomList.tsx
+++ b/src/pages/Services/Room/RoomList.tsx
@@ -11,6 +11,7 @@ function RoomList() {
       {roomRes && (
         <CustomTable
           data={roomRes.roomList}
+          columnSize={[10, 20, 15, 35, 10]}
         />
       )}
     </S.Container>

--- a/src/pages/Services/Room/RoomList.tsx
+++ b/src/pages/Services/Room/RoomList.tsx
@@ -1,9 +1,11 @@
 import CustomTable from 'components/common/CustomTable';
+import { useState } from 'react';
 import { useGetRoomListQuery } from 'store/api/room';
 import * as S from './RoomList.style';
 
 function RoomList() {
-  const { data: roomRes } = useGetRoomListQuery(1);
+  const [page, setPage] = useState(1);
+  const { data: roomRes } = useGetRoomListQuery(page);
 
   return (
     <S.Container>
@@ -11,6 +13,11 @@ function RoomList() {
       {roomRes && (
         <CustomTable
           data={roomRes.roomList}
+          pagination={{
+            current: page,
+            onChange: setPage,
+            total: roomRes.totalPage,
+          }}
           columnSize={[10, 20, 15, 35, 10]}
         />
       )}

--- a/src/pages/UserManage/User/UserDetail.style.tsx
+++ b/src/pages/UserManage/User/UserDetail.style.tsx
@@ -16,12 +16,6 @@ export const SubHeading = styled.div`
 
 export const FormWrapper = styled.div`
   padding: 10px 120px 60px 20px;
-  .ant-form-item-label > label {
-    font-size: 15px;
-    font-weight: 600;
-    color: #2c3e50;
-  }
-
   .ant-divider-with-text {
     font-size: 15px;
     font-weight: 600;

--- a/src/pages/UserManage/User/UserList.tsx
+++ b/src/pages/UserManage/User/UserList.tsx
@@ -13,13 +13,11 @@ function UserList() {
       {usersRes && (
         <CustomTable
           data={usersRes.userList}
-          pagination={
-          {
+          pagination={{
             current: page,
             onChange: setPage,
             total: usersRes.totalPage,
-          }
-}
+          }}
         />
       )}
     </S.Container>

--- a/src/pages/UserManage/User/UserList.tsx
+++ b/src/pages/UserManage/User/UserList.tsx
@@ -18,6 +18,7 @@ function UserList() {
             onChange: setPage,
             total: usersRes.totalPage,
           }}
+          columnSize={[10, 20, 20, 15, 20, 15]}
         />
       )}
     </S.Container>

--- a/src/store/api/room/index.ts
+++ b/src/store/api/room/index.ts
@@ -21,23 +21,22 @@ export const roomApi = createApi({
   }),
 
   endpoints: (builder) => ({
-    getRoomList: builder.query<{ roomList: RoomTableHead[] }, number>({
-      // TODO: admin get api로 변경. (페이지 네이션이 추가되면 그에 맞춰 메인 캐싱도 변경)
-      query: () => ({ url: 'lands' }),
-      providesTags: [{ type: 'rooms', id: 'LIST' }],
-
-      transformResponse:
-        (roomResponse: RoomsResponse):
-        { roomList: RoomTableHead[] } => {
-          const tableData = roomResponse.lands?.map(({
-            id, name, room_type, monthly_fee, charter_fee,
-          }) => ({
-            id, name, room_type, monthly_fee, charter_fee,
-          }));
-          return {
-            roomList: tableData,
-          };
-        },
+    getRoomList: builder.query<{ roomList: RoomTableHead[], totalPage: number }, number>({
+      query: (page) => ({ url: `admin/lands?page=${page}` }),
+      providesTags: (result) => (result
+        ? [...result.roomList.map((room) => ({ type: 'room' as const, id: room.id })), { type: 'rooms', id: 'LIST' }]
+        : [{ type: 'rooms', id: 'LIST' }]),
+      transformResponse: (roomResponse: RoomsResponse) => {
+        const tableData = roomResponse.lands?.map(({
+          id, name, room_type, monthly_fee, charter_fee,
+        }) => ({
+          id, name, room_type, monthly_fee, charter_fee,
+        }));
+        return {
+          roomList: tableData,
+          totalPage: roomResponse.totalPage,
+        };
+      },
     }),
 
     getRoom: builder.query<RoomResponse, number>({

--- a/src/store/api/room/index.ts
+++ b/src/store/api/room/index.ts
@@ -34,7 +34,7 @@ export const roomApi = createApi({
         }));
         return {
           roomList: tableData,
-          totalPage: roomResponse.totalPage,
+          totalPage: roomResponse.total_page,
         };
       },
     }),

--- a/src/store/api/room/index.ts
+++ b/src/store/api/room/index.ts
@@ -26,17 +26,10 @@ export const roomApi = createApi({
       providesTags: (result) => (result
         ? [...result.roomList.map((room) => ({ type: 'room' as const, id: room.id })), { type: 'rooms', id: 'LIST' }]
         : [{ type: 'rooms', id: 'LIST' }]),
-      transformResponse: (roomResponse: RoomsResponse) => {
-        const tableData = roomResponse.lands?.map(({
-          id, name, room_type, monthly_fee, charter_fee,
-        }) => ({
-          id, name, room_type, monthly_fee, charter_fee,
-        }));
-        return {
-          roomList: tableData,
-          totalPage: roomResponse.total_page,
-        };
-      },
+      transformResponse: (roomResponse: RoomsResponse) => ({
+        roomList: roomResponse.lands,
+        totalPage: roomResponse.total_page,
+      }),
     }),
 
     getRoom: builder.query<RoomResponse, number>({

--- a/src/store/api/user/index.ts
+++ b/src/store/api/user/index.ts
@@ -24,7 +24,7 @@ export const userApi = createApi({
         : [{ type: 'users', id: 'LIST' }]),
       transformResponse: (usersResponse: UsersResponse) => ({
         userList: usersResponse.users,
-        totalPage: usersResponse.totalPage,
+        totalPage: usersResponse.total_page,
       }),
     }),
 

--- a/src/store/api/user/index.ts
+++ b/src/store/api/user/index.ts
@@ -23,22 +23,10 @@ export const userApi = createApi({
         ? [...result.userList.map((user) => ({ type: 'user' as const, id: user.id })), { type: 'users', id: 'LIST' }]
         : [{ type: 'users', id: 'LIST' }]),
       transformResponse:
-        (usersResponse: UsersResponse): { userList: UserTableHead[], totalPage: number } => {
-          const tableData = usersResponse.items.map(({
-            id, portal_account, identity, nickname, name,
-          }) => ({
-            id,
-            portal_account,
-            identity,
-            nickname,
-            name,
-          }));
-
-          return {
-            userList: tableData,
-            totalPage: usersResponse.totalPage,
-          };
-        },
+        (usersResponse: UsersResponse): { userList: UserTableHead[], totalPage: number } => ({
+          userList: usersResponse.users,
+          totalPage: usersResponse.totalPage,
+        }),
     }),
 
     getUser: builder.query<UserDetail, number>({

--- a/src/store/api/user/index.ts
+++ b/src/store/api/user/index.ts
@@ -22,11 +22,10 @@ export const userApi = createApi({
       providesTags: (result) => (result
         ? [...result.userList.map((user) => ({ type: 'user' as const, id: user.id })), { type: 'users', id: 'LIST' }]
         : [{ type: 'users', id: 'LIST' }]),
-      transformResponse:
-        (usersResponse: UsersResponse): { userList: UserTableHead[], totalPage: number } => ({
-          userList: usersResponse.users,
-          totalPage: usersResponse.totalPage,
-        }),
+      transformResponse: (usersResponse: UsersResponse) => ({
+        userList: usersResponse.users,
+        totalPage: usersResponse.totalPage,
+      }),
     }),
 
     getUser: builder.query<UserDetail, number>({


### PR DESCRIPTION
## API 변경 적용

- GET: `/users`api가 반환하는 값이 변경되어 맞춰서 타입을 수정했습니다.
- GET: `/admin/lands` 및 `/admin/lands/${id}`api가 추가되어 해당 부분 페이지네이션과 함께 적용했습니다.
  - 페이지네이션 관련 프로퍼티들을 모아 `model/common.model.ts` 파일에 `ListResponsePagination`로 분리해 재사용했습니다.

## 테이블 너비 추가

- 이제 `<CustomTable />` 태그에 `columnSize: number[]`를 추가해 너비를 고정할 수 있습니다.
  - 페이지를 변경할 때마다 행 너비가 유동적으로 변하지 않게끔 고정했습니다.
- `[10, 20, 30, 40]` 은 각각 `width: "10%", ...` 로 변환돼 적용됩니다.

![tablewidth](https://user-images.githubusercontent.com/50780281/207038746-5bdf650f-3fb6-401e-936b-29243d4efdb5.gif)

