### PR TITLE
Feature/BCSD 멤버 목록 페이지 기능 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -61,7 +61,8 @@
     }],
     "no-param-reassign": "off",
     "import/no-cycle": "off",
-    "linebreak-style": "off"
+    "linebreak-style": "off",
+    "arrow-body-style": "off"
   },
   "settings": {
     "import/resolver": {

--- a/src/model/member.model.ts
+++ b/src/model/member.model.ts
@@ -31,4 +31,5 @@ export interface MemberTableHead {
   position: Position;
   image_url: string;
   email: string;
+  student_number: string;
 }

--- a/src/model/member.model.ts
+++ b/src/model/member.model.ts
@@ -32,4 +32,5 @@ export interface MemberTableHead {
   image_url: string;
   email: string;
   student_number: string;
+  is_deleted: boolean;
 }

--- a/src/pages/Services/Room/RoomList.tsx
+++ b/src/pages/Services/Room/RoomList.tsx
@@ -9,7 +9,7 @@ import AddRoomModal from './AddRoomModal';
 function RoomList() {
   const [page, setPage] = useState(1);
   const { data: roomRes } = useGetRoomListQuery(page);
-  const { setTrue: openModal, isValue: isModalOpen, setFalse: closeModal } = useBooleanState();
+  const { setTrue: openModal, value: isModalOpen, setFalse: closeModal } = useBooleanState();
 
   return (
     <S.Container>

--- a/src/pages/UserManage/Member/MemberList.style.tsx
+++ b/src/pages/UserManage/Member/MemberList.style.tsx
@@ -34,9 +34,13 @@ export const Tabs = styled.div`
 `;
 
 export const CardList = styled.div`
-  padding: 30px;
+  padding: 20px 30px;
   display: flex;
   flex-wrap: wrap;
   gap: 20px;
   justify-content: center;
+`;
+
+export const SwitchWrapper = styled.div`
+  margin: 40px 40px 0;
 `;

--- a/src/pages/UserManage/Member/MemberList.tsx
+++ b/src/pages/UserManage/Member/MemberList.tsx
@@ -1,5 +1,5 @@
 import { TRACK_LIST, TRACK_MAPPER } from 'constant/member';
-import { MemberTableHead, Track } from 'model/member.model';
+import { Track } from 'model/member.model';
 import { useState } from 'react';
 import { useGetMemberListQuery } from 'store/api/member';
 import useBooleanState from 'utils/hooks/useBoolean';
@@ -11,15 +11,6 @@ const POSITION_SCORE = {
   Mentor: 3,
   Regular: 2,
   Beginner: 1,
-};
-
-const comparePosition = (a: MemberTableHead, b:MemberTableHead) => {
-  return POSITION_SCORE[b.position] - POSITION_SCORE[a.position];
-};
-
-const makeMemberFilter = (containDeletedMember:boolean) => (member: MemberTableHead) => {
-  // is_deleted가 false라면, containDeletedMember값에 따라 필터링합니다.
-  return containDeletedMember || !member.is_deleted;
 };
 
 function MemberList() {
@@ -48,7 +39,6 @@ function MemberList() {
             selected={track === currentTrack}
           >
             {track}
-
           </S.Tab>
         ))}
       </S.Tabs>
@@ -65,8 +55,8 @@ function MemberList() {
       {membersRes && (
         <S.CardList>
           {membersRes.memberList
-            .filter(makeMemberFilter(containDeletedMember))
-            .sort(comparePosition)
+            .filter((member) => containDeletedMember || !member.is_deleted)
+            .sort((a, b) => POSITION_SCORE[b.position] - POSITION_SCORE[a.position])
             .map((member) => (
               <MemberCard member={member} key={member.id} />
             ))}

--- a/src/pages/UserManage/Member/component/MemberCard.style.tsx
+++ b/src/pages/UserManage/Member/component/MemberCard.style.tsx
@@ -40,7 +40,11 @@ export const ProfileImg = styled.img<{ position: PositionType }>`
 
   border-width: 3px;
   border-style: solid;
-  border-color: ${({ position }) => (position === 'Mentor' ? '#795cf2' : '#1abc9c')};
+  border-color: ${({ position }) => {
+    if (position === 'Mentor') return '#795cf2';
+    if (position === 'Regular') return '#1abc9c';
+    return '#81d4fa';
+  }};
 `;
 
 export const UserName = styled.div`
@@ -56,7 +60,11 @@ export const Position = styled.div<{ position: PositionType }>`
   align-self: flex-start;
   letter-spacing: -.39px;
 
-  color: ${({ position }) => (position === 'Mentor' ? '#795cf2' : '#1abc9c')};
+  color: ${({ position }) => {
+    if (position === 'Mentor') return '#795cf2';
+    if (position === 'Regular') return '#1abc9c';
+    return '#81d4fa';
+  }};
 `;
 
 export const Label = styled.div`

--- a/src/pages/UserManage/Member/component/MemberCard.tsx
+++ b/src/pages/UserManage/Member/component/MemberCard.tsx
@@ -8,12 +8,12 @@ export default function MemberCard({ member }: { member: MemberTableHead }) {
   return (
     <S.Card onClick={() => navigate(`${member.id}`)}>
       <S.ProfileCover>
-        <S.ProfileImg position={member.position} src="https://static.koreatech.in/bcsdlab_page_assets/img/people/sjr.jpg" />
+        <S.ProfileImg position={member.position} src={member.image_url} />
       </S.ProfileCover>
       <S.Position position={member.position}>{member.position}</S.Position>
       <S.UserName>{member.name}</S.UserName>
       <S.StudentNumberLabel>Student No.</S.StudentNumberLabel>
-      <S.Description>2019136133</S.Description>
+      <S.Description>{member.student_number}</S.Description>
       <S.Label>Email</S.Label>
       <S.Description>{member.email}</S.Description>
     </S.Card>

--- a/src/utils/hooks/useBoolean.ts
+++ b/src/utils/hooks/useBoolean.ts
@@ -1,13 +1,13 @@
 import { useState } from 'react';
 
 export default function useBooleanState(defaultValue?: boolean) {
-  const [isValue, setIsValue] = useState(!!defaultValue);
+  const [value, setValue] = useState(!!defaultValue);
 
-  const setTrue = () => setIsValue(true);
-  const setFalse = () => setIsValue(false);
-  const changeValue = () => setIsValue((x) => !x);
+  const setTrue = () => setValue(true);
+  const setFalse = () => setValue(false);
+  const changeValue = () => setValue((x) => !x);
 
   return {
-    isValue, setIsValue, setTrue, setFalse, changeValue,
+    value, setValue, setTrue, setFalse, changeValue,
   } as const;
 }


### PR DESCRIPTION
## 추가된 기능
서버 API response가 변경되어 지난 PR(#7) 에서 언급되었던 부분들과 함께 변경 사항들을 적용했습니다.
- 프로필사진과 학번을 서버 데이터를 받아와 보여주게끔 수정했습니다.
- `is_deleted`필드를 활용해 탈퇴 인원을 필터링하는 기능을 추가했습니다. (기본적으로 필터링)
- 탈퇴인원들 중 대부분이 비기너인지라, 레귤러와 비기너가 구분되게끔 비기너 색상을 추가했습니다.
- `useBooleanState` 훅을 쓰던 중 isValue라는 표현이 어색해보여 value로 바꿨습니다.

## ScreenShot
![newadmin](https://user-images.githubusercontent.com/50780281/211208072-6af0c968-c9a0-42e2-96aa-042096b57782.gif)

## Precautions
`memberList`에 filter, sort가 동시에 적용되어 해당 상태를 파악하는 데 불편할 수 있다고 생각이 들어서.. 가독성을 높이는 방법이 있을지?를 집중적으로 리뷰해주시면 좋을 것 같아요.