### PR TITLE
Feature/BCSD 멤버 추가, 삭제 복구 기능 추가

### DIFF
--- a/src/components/common/CustomForm/CustomSingleUpload.tsx
+++ b/src/components/common/CustomForm/CustomSingleUpload.tsx
@@ -30,7 +30,7 @@ export default function CustomSingleUpload({ form, domain, name }: Props) {
   const [uploadFileList, setUploadFileList] = useState<string[]>([form.getFieldValue(name)]);
   let convertedFileList: UploadFile[] = [];
 
-  if (uploadFileList[0] !== null) {
+  if (uploadFileList[0]) {
     convertedFileList = uploadFileList?.map(convertUploadFile);
   }
 

--- a/src/model/member.model.ts
+++ b/src/model/member.model.ts
@@ -22,6 +22,7 @@ export interface MembersResponse extends ListPagination {
 export interface MembersParam {
   page: number;
   track: TrackForParam;
+  is_deleted: boolean;
 }
 
 export interface MemberTableHead {

--- a/src/pages/UserManage/Member/MemberDetail.tsx
+++ b/src/pages/UserManage/Member/MemberDetail.tsx
@@ -12,7 +12,7 @@ function MemberDetail() {
   const { id } = useParams();
   const { data: memberData } = useGetMemberQuery(Number(id));
   const [form] = CustomForm.useForm();
-  const { updateMember, deleteMember, unDeleteMember } = useMemberMutation(Number(id));
+  const { updateMember, deleteMember, undeleteMember } = useMemberMutation(Number(id));
 
   return (
     <S.Container>
@@ -36,7 +36,7 @@ function MemberDetail() {
                 </CustomForm.Button>
                 {memberData.is_deleted
                   ? (
-                    <CustomForm.Button danger icon={<ReloadOutlined />} onClick={unDeleteMember}>
+                    <CustomForm.Button danger icon={<ReloadOutlined />} onClick={undeleteMember}>
                       유저 복구
                     </CustomForm.Button>
                   )

--- a/src/pages/UserManage/Member/MemberDetail.tsx
+++ b/src/pages/UserManage/Member/MemberDetail.tsx
@@ -1,4 +1,4 @@
-import { DeleteOutlined, UploadOutlined } from '@ant-design/icons';
+import { DeleteOutlined, ReloadOutlined, UploadOutlined } from '@ant-design/icons';
 import { Divider } from 'antd';
 import CustomForm from 'components/common/CustomForm';
 import { useParams } from 'react-router-dom';
@@ -12,7 +12,7 @@ function MemberDetail() {
   const { id } = useParams();
   const { data: memberData } = useGetMemberQuery(Number(id));
   const [form] = CustomForm.useForm();
-  const { updateMember, deleteMember } = useMemberMutation(Number(id));
+  const { updateMember, deleteMember, unDeleteMember } = useMemberMutation(Number(id));
 
   return (
     <S.Container>
@@ -34,9 +34,17 @@ function MemberDetail() {
                 <CustomForm.Button icon={<UploadOutlined />} htmlType="submit">
                   정보 수정
                 </CustomForm.Button>
-                <CustomForm.Button danger icon={<DeleteOutlined />} onClick={deleteMember}>
-                  유저 삭제
-                </CustomForm.Button>
+                {memberData.is_deleted
+                  ? (
+                    <CustomForm.Button danger icon={<ReloadOutlined />} onClick={unDeleteMember}>
+                      유저 복구
+                    </CustomForm.Button>
+                  )
+                  : (
+                    <CustomForm.Button danger icon={<DeleteOutlined />} onClick={deleteMember}>
+                      유저 삭제
+                    </CustomForm.Button>
+                  )}
               </S.ButtonWrap>
             </CustomForm>
           </S.FormWrapper>

--- a/src/pages/UserManage/Member/MemberDetail.tsx
+++ b/src/pages/UserManage/Member/MemberDetail.tsx
@@ -4,9 +4,9 @@ import CustomForm from 'components/common/CustomForm';
 import { useParams } from 'react-router-dom';
 import DetailHeading from 'components/common/DetailHeading';
 import { useGetMemberQuery } from 'store/api/member';
-import { SELECT_OPTIONS } from 'constant/member';
 import * as S from './MemberDetail.style';
 import useMemberMutation from './useMemberMutation';
+import DetailForm from './components/DetailForm';
 
 function MemberDetail() {
   const { id } = useParams();
@@ -29,21 +29,7 @@ function MemberDetail() {
               initialValues={memberData}
               onFinish={updateMember}
             >
-              <Divider orientation="left">기본 정보</Divider>
-              <CustomForm.InputNumber label="ID" name="id" disabled />
-              <CustomForm.Input label="이름" name="name" />
-              <CustomForm.GridRow gridColumns="1fr 1fr">
-                <CustomForm.Select label="트랙" name="track" options={SELECT_OPTIONS.track} />
-                <CustomForm.Select label="직책" name="position" options={SELECT_OPTIONS.position} />
-              </CustomForm.GridRow>
-              <CustomForm.Input label="이메일" name="email" />
-              <CustomForm.Input label="학번" name="student_number" />
-
-              <Divider orientation="left">사진</Divider>
-              <S.UploadWrap>
-                <CustomForm.SingleUpload domain="members" name="image_url" form={form} />
-              </S.UploadWrap>
-
+              <DetailForm form={form} />
               <S.ButtonWrap>
                 <CustomForm.Button icon={<UploadOutlined />} htmlType="submit">
                   정보 수정

--- a/src/pages/UserManage/Member/MemberList.style.tsx
+++ b/src/pages/UserManage/Member/MemberList.style.tsx
@@ -34,7 +34,6 @@ export const Tabs = styled.div`
 `;
 
 export const CardList = styled.div`
-  padding: 20px 30px;
   display: flex;
   flex-wrap: wrap;
   gap: 20px;
@@ -43,4 +42,22 @@ export const CardList = styled.div`
 
 export const SwitchWrapper = styled.div`
   margin: 40px 40px 0;
+`;
+
+export const DetailFormWrap = styled.div`
+  padding: 0 40px;
+`;
+
+export const SubmitButtonWrap = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 100px;
+`;
+
+export const ModalWrap = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 30px;
+  margin-right: 70px;
+
 `;

--- a/src/pages/UserManage/Member/MemberList.style.tsx
+++ b/src/pages/UserManage/Member/MemberList.style.tsx
@@ -59,5 +59,4 @@ export const ModalWrap = styled.div`
   justify-content: flex-end;
   margin-bottom: 30px;
   margin-right: 70px;
-
 `;

--- a/src/pages/UserManage/Member/MemberList.tsx
+++ b/src/pages/UserManage/Member/MemberList.tsx
@@ -4,8 +4,10 @@ import { useState } from 'react';
 import { useGetMemberListQuery } from 'store/api/member';
 import useBooleanState from 'utils/hooks/useBoolean';
 import { Switch } from 'antd';
+import CustomForm from 'components/common/CustomForm';
 import * as S from './MemberList.style';
 import MemberCard from './components/MemberCard';
+import AddMemberModal from './components/AddMemberModal';
 
 const POSITION_SCORE = {
   Mentor: 3,
@@ -24,11 +26,26 @@ function MemberList() {
     changeValue: toggleContainDeletedMember,
   } = useBooleanState(false);
 
+  const { setTrue: openModal, value: isModalOpen, setFalse: closeModal } = useBooleanState();
+
   return (
     <div>
       <h1>
         Member
       </h1>
+      <S.ModalWrap>
+        <CustomForm.Modal
+          buttonText="생성"
+          title="등록하기"
+          width={900}
+          footer={null}
+          open={isModalOpen}
+          onCancel={closeModal}
+          onClick={openModal}
+        >
+          <AddMemberModal onCancel={closeModal} />
+        </CustomForm.Modal>
+      </S.ModalWrap>
 
       <S.Tabs>
         {TRACK_LIST.map((track) => (

--- a/src/pages/UserManage/Member/MemberList.tsx
+++ b/src/pages/UserManage/Member/MemberList.tsx
@@ -9,23 +9,14 @@ import * as S from './MemberList.style';
 import MemberCard from './components/MemberCard';
 import AddMemberModal from './components/AddMemberModal';
 
-const POSITION_SCORE = {
-  Mentor: 3,
-  Regular: 2,
-  Beginner: 1,
-};
-
 function MemberList() {
   const [currentTrack, setTrack] = useState<Track>('FrontEnd');
+  const { value: isDeleted, changeValue: handleDeleted } = useBooleanState(false);
   const { data: membersRes } = useGetMemberListQuery({
     page: 1,
     track: TRACK_MAPPER[currentTrack],
+    is_deleted: isDeleted,
   });
-  const {
-    value: containDeletedMember,
-    changeValue: toggleContainDeletedMember,
-  } = useBooleanState(false);
-
   const { setTrue: openModal, value: isModalOpen, setFalse: closeModal } = useBooleanState();
 
   return (
@@ -62,18 +53,16 @@ function MemberList() {
 
       <S.SwitchWrapper>
         <Switch
-          onClick={toggleContainDeletedMember}
-          checked={containDeletedMember}
-          checkedChildren="탈퇴 인원 포함"
-          unCheckedChildren="탈퇴 인원 포함"
+          onClick={handleDeleted}
+          checked={isDeleted}
+          checkedChildren="탈퇴 인원"
+          unCheckedChildren="현재 인원"
         />
       </S.SwitchWrapper>
 
       {membersRes && (
         <S.CardList>
-          {membersRes.memberList
-            .filter((member) => containDeletedMember || !member.is_deleted)
-            .sort((a, b) => POSITION_SCORE[b.position] - POSITION_SCORE[a.position])
+          {membersRes?.memberList
             .map((member) => (
               <MemberCard member={member} key={member.id} />
             ))}

--- a/src/pages/UserManage/Member/MemberList.tsx
+++ b/src/pages/UserManage/Member/MemberList.tsx
@@ -9,6 +9,12 @@ import * as S from './MemberList.style';
 import MemberCard from './components/MemberCard';
 import AddMemberModal from './components/AddMemberModal';
 
+const POSITION_SCORE = {
+  Mentor: 2,
+  Regular: 1,
+  Beginner: 0,
+};
+
 function MemberList() {
   const [currentTrack, setTrack] = useState<Track>('FrontEnd');
   const { value: isDeleted, changeValue: handleDeleted } = useBooleanState(false);
@@ -63,6 +69,8 @@ function MemberList() {
       {membersRes && (
         <S.CardList>
           {membersRes?.memberList
+            .slice()
+            .sort((a, b) => POSITION_SCORE[b.position] - POSITION_SCORE[a.position])
             .map((member) => (
               <MemberCard member={member} key={member.id} />
             ))}

--- a/src/pages/UserManage/Member/components/AddMemberModal.tsx
+++ b/src/pages/UserManage/Member/components/AddMemberModal.tsx
@@ -1,0 +1,34 @@
+/* eslint-disable no-restricted-imports */
+import { UploadOutlined } from '@ant-design/icons';
+import CustomForm from 'components/common/CustomForm';
+import { Member } from 'model/member.model';
+import DetailForm from './DetailForm';
+import * as S from '../MemberList.style';
+import useMemberMutation from '../useMemberMutation';
+
+export default function AddMemberModal({ onCancel }: { onCancel: () => void }) {
+  const [form] = CustomForm.useForm();
+  const { addMember } = useMemberMutation(1);
+
+  const createMember = (values: Partial<Member>) => {
+    addMember(values);
+    onCancel();
+    form.resetFields();
+  };
+
+  return (
+    <CustomForm
+      onFinish={createMember}
+      form={form}
+    >
+      <S.DetailFormWrap>
+        <DetailForm form={form} />
+        <S.SubmitButtonWrap>
+          <CustomForm.Button icon={<UploadOutlined />} htmlType="submit">
+            완료
+          </CustomForm.Button>
+        </S.SubmitButtonWrap>
+      </S.DetailFormWrap>
+    </CustomForm>
+  );
+}

--- a/src/pages/UserManage/Member/components/DetailForm.tsx
+++ b/src/pages/UserManage/Member/components/DetailForm.tsx
@@ -16,7 +16,7 @@ export default function DetailForm({ form }: { form: FormInstance }) {
         <CustomForm.Select label="직책" name="position" options={SELECT_OPTIONS.position} />
       </CustomForm.GridRow>
       <CustomForm.Input label="이메일" name="email" />
-      <CustomForm.Input label="학번" name="student_number" />
+      <CustomForm.InputNumber label="학번" name="student_number" />
 
       <Divider orientation="left">사진</Divider>
       <S.UploadWrap>

--- a/src/pages/UserManage/Member/components/DetailForm.tsx
+++ b/src/pages/UserManage/Member/components/DetailForm.tsx
@@ -1,0 +1,27 @@
+/* eslint-disable no-restricted-imports */
+import { Divider } from 'antd';
+import CustomForm from 'components/common/CustomForm';
+import { SELECT_OPTIONS } from 'constant/member';
+import { FormInstance } from 'antd/es/form/Form';
+import * as S from '../MemberDetail.style';
+
+export default function DetailForm({ form }: { form: FormInstance }) {
+  return (
+    <>
+      <Divider orientation="left">기본 정보</Divider>
+      <CustomForm.InputNumber label="ID" name="id" disabled />
+      <CustomForm.Input label="이름" name="name" />
+      <CustomForm.GridRow gridColumns="1fr 1fr">
+        <CustomForm.Select label="트랙" name="track" options={SELECT_OPTIONS.track} />
+        <CustomForm.Select label="직책" name="position" options={SELECT_OPTIONS.position} />
+      </CustomForm.GridRow>
+      <CustomForm.Input label="이메일" name="email" />
+      <CustomForm.Input label="학번" name="student_number" />
+
+      <Divider orientation="left">사진</Divider>
+      <S.UploadWrap>
+        <CustomForm.SingleUpload domain="members" name="image_url" form={form} />
+      </S.UploadWrap>
+    </>
+  );
+}

--- a/src/pages/UserManage/Member/useMemberMutation.tsx
+++ b/src/pages/UserManage/Member/useMemberMutation.tsx
@@ -2,14 +2,14 @@ import { message } from 'antd';
 import { Member } from 'model/member.model';
 import { useNavigate } from 'react-router-dom';
 import {
-  useAddMemberMutation, useDeleteMemberMutation, useUnDeleteMemberMutation, useUpdateMemberMutation,
+  useAddMemberMutation, useDeleteMemberMutation, useUndeleteMemberMutation, useUpdateMemberMutation,
 } from 'store/api/member';
 
 export default function useMemberMutation(id: number) {
   const [updateMemberMutation] = useUpdateMemberMutation();
   const [deleteMemberMutation] = useDeleteMemberMutation();
   const [addMemberMutation] = useAddMemberMutation();
-  const [unDeleteMemberMutation] = useUnDeleteMemberMutation();
+  const [undeleteMemberMutation] = useUndeleteMemberMutation();
   const navigate = useNavigate();
 
   const updateMember = (formData: Partial<Member>) => {
@@ -50,8 +50,8 @@ export default function useMemberMutation(id: number) {
     }
   }
 
-  function unDeleteMember() {
-    unDeleteMemberMutation(id)
+  function undeleteMember() {
+    undeleteMemberMutation(id)
       .unwrap()
       .then(() => {
         message.success('복구되었습니다..');
@@ -62,6 +62,6 @@ export default function useMemberMutation(id: number) {
   }
 
   return {
-    updateMember, deleteMember, addMember, unDeleteMember,
+    updateMember, deleteMember, addMember, undeleteMember,
   };
 }

--- a/src/pages/UserManage/Member/useMemberMutation.tsx
+++ b/src/pages/UserManage/Member/useMemberMutation.tsx
@@ -1,11 +1,12 @@
 import { message } from 'antd';
 import { Member } from 'model/member.model';
 import { useNavigate } from 'react-router-dom';
-import { useDeleteMemberMutation, useUpdateMemberMutation } from 'store/api/member';
+import { useAddMemberMutation, useDeleteMemberMutation, useUpdateMemberMutation } from 'store/api/member';
 
 export default function useMemberMutation(id: number) {
   const [updateMemberMutation] = useUpdateMemberMutation();
   const [deleteMemberMutation] = useDeleteMemberMutation();
+  const [addMemberMutation] = useAddMemberMutation();
   const navigate = useNavigate();
 
   const updateMember = (formData: Partial<Member>) => {
@@ -33,5 +34,18 @@ export default function useMemberMutation(id: number) {
       }));
   }
 
-  return { updateMember, deleteMember };
+  function addMember(formData: Partial<Member>) {
+    if (FormData) {
+      addMemberMutation(formData)
+        .unwrap()
+        .then(() => {
+          message.success('추가되었습니다.');
+        })
+        .catch(({ data }) => {
+          message.error(data.error.message);
+        });
+    }
+  }
+
+  return { updateMember, deleteMember, addMember };
 }

--- a/src/pages/UserManage/Member/useMemberMutation.tsx
+++ b/src/pages/UserManage/Member/useMemberMutation.tsx
@@ -1,12 +1,15 @@
 import { message } from 'antd';
 import { Member } from 'model/member.model';
 import { useNavigate } from 'react-router-dom';
-import { useAddMemberMutation, useDeleteMemberMutation, useUpdateMemberMutation } from 'store/api/member';
+import {
+  useAddMemberMutation, useDeleteMemberMutation, useUnDeleteMemberMutation, useUpdateMemberMutation,
+} from 'store/api/member';
 
 export default function useMemberMutation(id: number) {
   const [updateMemberMutation] = useUpdateMemberMutation();
   const [deleteMemberMutation] = useDeleteMemberMutation();
   const [addMemberMutation] = useAddMemberMutation();
+  const [unDeleteMemberMutation] = useUnDeleteMemberMutation();
   const navigate = useNavigate();
 
   const updateMember = (formData: Partial<Member>) => {
@@ -47,5 +50,18 @@ export default function useMemberMutation(id: number) {
     }
   }
 
-  return { updateMember, deleteMember, addMember };
+  function unDeleteMember() {
+    unDeleteMemberMutation(id)
+      .unwrap()
+      .then(() => {
+        message.success('복구되었습니다..');
+        navigate(-1);
+      }).catch((({ data }) => {
+        message.error(data.error.message);
+      }));
+  }
+
+  return {
+    updateMember, deleteMember, addMember, unDeleteMember,
+  };
 }

--- a/src/store/api/member/index.ts
+++ b/src/store/api/member/index.ts
@@ -70,10 +70,20 @@ export const memberApi = createApi({
       }),
       invalidatesTags: [{ type: 'members', id: 'LIST' }],
     }),
+
+    unDeleteMember: builder.mutation<void, number>({
+      query: (id) => {
+        return {
+          url: `admin/members/${id}/undelete`,
+          method: 'POST',
+        };
+      },
+      invalidatesTags: (result, error, id) => [{ type: 'member', id }, { type: 'members', id: 'LIST' }],
+    }),
   }),
 });
 
 export const {
-  useGetMemberListQuery, useGetMemberQuery,
+  useGetMemberListQuery, useGetMemberQuery, useUnDeleteMemberMutation,
   useUpdateMemberMutation, useDeleteMemberMutation, useAddMemberMutation,
 } = memberApi;

--- a/src/store/api/member/index.ts
+++ b/src/store/api/member/index.ts
@@ -23,7 +23,7 @@ export const memberApi = createApi({
       memberList: MemberTableHead[],
       totalPage: number
     }, MembersParam>({
-      query: ({ page, track }) => `admin/members/?page=${page}&track=${track}&limit=50`,
+      query: ({ page, track, is_deleted }) => `admin/members/?page=${page}&track=${track}&limit=50&is_deleted=${is_deleted}`,
       providesTags: (result) => (result
         ? [...result.memberList.map((member) => ({ type: 'member' as const, id: member.id })), { type: 'members', id: 'LIST' }]
         : [{ type: 'members', id: 'LIST' }]),

--- a/src/store/api/member/index.ts
+++ b/src/store/api/member/index.ts
@@ -61,10 +61,19 @@ export const memberApi = createApi({
         { type: 'member', id }, { type: 'members', id: 'LIST' },
       ]),
     }),
+
+    addMember: builder.mutation<Member, Partial<Member>>({
+      query: (body) => ({
+        url: 'admin/members',
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: [{ type: 'members', id: 'LIST' }],
+    }),
   }),
 });
 
 export const {
   useGetMemberListQuery, useGetMemberQuery,
-  useUpdateMemberMutation, useDeleteMemberMutation,
+  useUpdateMemberMutation, useDeleteMemberMutation, useAddMemberMutation,
 } = memberApi;

--- a/src/store/api/member/index.ts
+++ b/src/store/api/member/index.ts
@@ -71,7 +71,7 @@ export const memberApi = createApi({
       invalidatesTags: [{ type: 'members', id: 'LIST' }],
     }),
 
-    unDeleteMember: builder.mutation<void, number>({
+    undeleteMember: builder.mutation<void, number>({
       query: (id) => {
         return {
           url: `admin/members/${id}/undelete`,
@@ -84,6 +84,6 @@ export const memberApi = createApi({
 });
 
 export const {
-  useGetMemberListQuery, useGetMemberQuery, useUnDeleteMemberMutation,
+  useGetMemberListQuery, useGetMemberQuery, useUndeleteMemberMutation,
   useUpdateMemberMutation, useDeleteMemberMutation, useAddMemberMutation,
 } = memberApi;


### PR DESCRIPTION
## 멤버 추가
- POST `/admin/members` api 연결
- `useMemberMutation()` 에 `addMember` 추가
- `customForm.modal`을 이용해 추가 모달 생성
- detail page 로부터 `detailForm` 컴포넌트로 분리해 재사용

## 삭제 복구 기능 추가
- POST `/admin/members/{id}/undelete` api 연결
- `useMemberMutation()` 에 `undeleteMember` 추가
- 탈퇴 인원만 볼수있도록 member List `Switch` 기능 수정
- GET `admin/member`에 `is_delete` 파라미터 추가, 탈퇴 멤버 `filter()` 기능 삭제
- 탈퇴 인원일시,  detail page에 삭제 복구 기능 추가

--- 
- member 추가 모달
<img width="1013" alt="image" src="https://user-images.githubusercontent.com/101982606/216957585-3f13b885-2326-4add-ae11-c871b7819457.png">

- 탈퇴 인원 보기
<img width="938" alt="image" src="https://user-images.githubusercontent.com/101982606/216958912-116831ca-7d27-4799-8d10-e43d7deff546.png">
- 탈퇴 인원 detail page
<img width="837" alt="image" src="https://user-images.githubusercontent.com/101982606/216958118-dd9e4b9a-3dc2-447b-be45-9e9c8219bd90.png">
