### PR TITLE
Chore/antd-pro 라이브러리 삭제

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@ant-design/icons": "^4.7.0",
-    "@ant-design/pro-components": "^2.6.34",
     "@reduxjs/toolkit": "^1.8.5",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^13.0.0",


### PR DESCRIPTION
## antd-pro 라이브러리 삭제
antd-pro를 사용하지않아 라이브러리를 삭제했습니다.

**필요없는 라이브러리를 삭제하므로  배포할때 생겨나는 메모리 누수 문제를 해결할수있을것같습니다.