### PR TITLE
fix: 메뉴상세 수정

### DIFF
--- a/src/pages/Services/Store/StoreDetail.tsx
+++ b/src/pages/Services/Store/StoreDetail.tsx
@@ -47,9 +47,6 @@ export default function StoreDetail() {
             <Divider orientation="left" style={{ marginTop: '40px', marginBottom: '40px' }}>메뉴</Divider>
             <MenuList form={menuForm} />
             <S.ButtonWrap>
-              <CustomForm.Button icon={<UploadOutlined />} htmlType="submit">
-                완료
-              </CustomForm.Button>
               {storeData?.is_deleted
                 ? (
                   <CustomForm.Button danger icon={<ReloadOutlined />} onClick={undeleteStore}>
@@ -61,6 +58,9 @@ export default function StoreDetail() {
                     삭제
                   </CustomForm.Button>
                 )}
+              <CustomForm.Button icon={<UploadOutlined />} htmlType="submit">
+                완료
+              </CustomForm.Button>
             </S.ButtonWrap>
           </CustomForm>
         </S.FormWrap>

--- a/src/pages/Services/Store/components/MenuDetailForm.tsx
+++ b/src/pages/Services/Store/components/MenuDetailForm.tsx
@@ -43,7 +43,7 @@ export default function MenuDetailForm({ menuId, form }:{ menuId: number, form: 
           <Form.Item label="메뉴 이름" name="name">
             <Input name="name" />
           </Form.Item>
-          <Form.Item name="is_single">
+          <Form.Item name="is_single" valuePropName="checked">
             <Checkbox>단일 메뉴</Checkbox>
           </Form.Item>
           <Form.Item label="단일 메뉴 가격" name="single_price">

--- a/src/pages/Services/Store/components/MenuList.tsx
+++ b/src/pages/Services/Store/components/MenuList.tsx
@@ -20,9 +20,13 @@ export default function MenuList({ form }: { form: FormInstance }) {
   const [menuForm] = CustomForm.useForm();
 
   const handleClick = (selectedMenuId: number) => {
-    if (menuId && selectedMenuId !== menuId) {
+    if (menuId && selectedMenuId) {
       // 서버 500에러로 테스트 불가
       updateMenu(menuId, menuForm?.getFieldsValue());
+    }
+    if (selectedMenuId === menuId) {
+      setMenuId(undefined);
+      return;
     }
     setMenuId(selectedMenuId);
   };
@@ -55,10 +59,12 @@ export default function MenuList({ form }: { form: FormInstance }) {
                     {menuList.menus[field.name].id === menuId
                       && <MenuDetailForm menuId={menuId} form={menuForm} /> }
                   </Card>
-                  <DeleteOutlined onClick={async () => {
-                    await deleteMenu(menuList.menus[field.name].id);
-                    remove(field.name);
-                  }}
+                  <DeleteOutlined
+                    onClick={async () => {
+                      await deleteMenu(menuList.menus[field.name].id);
+                      remove(field.name);
+                    }}
+                    style={{ marginTop: 12 }}
                   />
                 </S.CardWrap>
               ))}

--- a/src/pages/Services/Store/components/OpenTimeForm.tsx
+++ b/src/pages/Services/Store/components/OpenTimeForm.tsx
@@ -3,6 +3,7 @@ import { Divider, Select, TimePicker } from 'antd';
 import { FormInstance } from 'antd/es/form/Form';
 import { StoreOpen } from 'model/store.model';
 import { useState } from 'react';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import CustomForm from 'components/common/CustomForm';
 import dayjs from 'dayjs';
 import * as S from '../StoreDetail.style';
@@ -23,10 +24,11 @@ const TABLE_TYPES = {
   },
 };
 
+dayjs.extend(customParseFormat);
+
 function OpenTimeForm({ form } : { form: FormInstance }) {
   const openTimeInfo: StoreOpen[] = form.getFieldValue('open');
   const [selectType, setSelectType] = useState<keyof typeof TABLE_TYPES>('직접 지정');
-
   const handleTimeFormChange = (index: number, key: keyof StoreOpen, value: string | boolean) => {
     const selected = TABLE_TYPES[selectType];
     for (let i = 0; i < selected.colSize[index]; i += 1) {


### PR DESCRIPTION
- dayjs가 순수 시간만 파싱하려면 커스텀 파서를 넣어줘야한다해서 추가했습니다.

```ts
import customParseFormat from 'dayjs/plugin/customParseFormat';

dayjs.extend(customParseFormat);
``` 

<img width="772" alt="image" src="https://github.com/BCSDLab/KOIN_ADMIN_V2/assets/50780281/d67e5b66-9c61-44c2-9348-f4c9f9a3a3b2">


- `is_single`이 checkbox value를 못잡고있어 `valuePropName`을 추가했습니다
- 추가로 아이콘 정렬 맞지않는 부분 수정했습니다.
- UX적으로 완료버튼이 오른쪽에 있는게 적절한 것 같아서 같이 수정했습니다.

<img width="562" alt="image" src="https://github.com/BCSDLab/KOIN_ADMIN_V2/assets/50780281/9c75c212-a7b6-4aa1-9f85-be13371a5369">
