### PR TITLE
Hotfix/ 상점 메뉴 사진 업로드 오류 수정

### DIFF
--- a/src/pages/Services/Store/StoreDetail.tsx
+++ b/src/pages/Services/Store/StoreDetail.tsx
@@ -14,7 +14,6 @@ export default function StoreDetail() {
   const { data: storeData } = useGetStoreQuery(Number(id));
   const { updateStore, deleteStore, undeleteStore } = useStoreMutation(Number(id));
   const [storeForm] = CustomForm.useForm();
-  const [menuForm] = CustomForm.useForm();
 
   const onFinish = (values: any) => {
     const updatedValues = { ...values };
@@ -45,7 +44,7 @@ export default function StoreDetail() {
             <StoreDetailForm form={storeForm} />
 
             <Divider orientation="left" style={{ marginTop: '40px', marginBottom: '40px' }}>메뉴</Divider>
-            <MenuList form={menuForm} />
+            <MenuList />
             <S.ButtonWrap>
               {storeData?.is_deleted
                 ? (

--- a/src/pages/Services/Store/components/MenuDetailForm.tsx
+++ b/src/pages/Services/Store/components/MenuDetailForm.tsx
@@ -82,8 +82,7 @@ export default function MenuDetailForm({ menuId, form }:{ menuId: number, form: 
           </Form.Item>
 
           <Divider orientation="left">사진</Divider>
-          <CustomForm.MultipleUpload domain="shops" name="image_urls" form={form} />
-
+          <CustomForm.MultipleUpload domain="market" name="image_urls" form={form} />
         </CustomForm>
       )}
     </div>

--- a/src/pages/Services/Store/components/MenuDetailForm.tsx
+++ b/src/pages/Services/Store/components/MenuDetailForm.tsx
@@ -6,7 +6,6 @@ import {
 } from 'antd';
 import { DeleteOutlined } from '@ant-design/icons';
 import { FormInstance } from 'antd/lib/form';
-import { useLayoutEffect } from 'react';
 import { useGetMenuCategoriesQuery } from 'store/api/storeMenu/category';
 import { MenuCategory } from 'model/menuCategory';
 
@@ -16,10 +15,9 @@ export default function MenuDetailForm({ menuId, form }:{ menuId: number, form: 
     id: Number(id), menuId,
   });
   const { data: menuCategories } = useGetMenuCategoriesQuery(Number(id));
-
-  useLayoutEffect(() => {
-    form.setFieldsValue(storeMenu);
-  });
+  // form 초기화
+  form.setFieldsValue(storeMenu);
+  form.setFieldValue('image_urls', storeMenu?.image_urls);
 
   const options = menuCategories?.menu_categories.map((category: MenuCategory) => ({
     label: category.name,

--- a/src/pages/Services/Store/components/MenuList.style.tsx
+++ b/src/pages/Services/Store/components/MenuList.style.tsx
@@ -28,4 +28,8 @@ export const CardWrap = styled.div<{ $id: number; $menuId?: number; }>`
       padding: 38px;
       display: ${(props) => (props.$id === props.$menuId ? 'block' : 'none')}
     }
+
+    .upload-list-inline .ant-upload-list-item {
+      width: 100%;
+    }
 `;

--- a/src/pages/Services/Store/components/MenuList.tsx
+++ b/src/pages/Services/Store/components/MenuList.tsx
@@ -3,7 +3,6 @@
 import CustomForm from 'components/common/CustomForm';
 import { Card } from 'antd';
 import { DeleteOutlined, PlusCircleOutlined } from '@ant-design/icons';
-import { FormInstance } from 'antd/lib/form';
 import { useParams } from 'react-router-dom';
 import { useGetMenusListQuery } from 'store/api/storeMenu';
 import { useState } from 'react';
@@ -11,7 +10,7 @@ import * as S from './MenuList.style';
 import MenuDetailForm from './MenuDetailForm';
 import useMenuMutation from './useMenuMutation';
 
-export default function MenuList({ form }: { form: FormInstance }) {
+export default function MenuList() {
   const { id } = useParams();
   const { data: storeMenusData } = useGetMenusListQuery(Number(id));
   const [menuId, setMenuId] = useState<number>();
@@ -21,7 +20,6 @@ export default function MenuList({ form }: { form: FormInstance }) {
 
   const handleClick = (selectedMenuId: number) => {
     if (menuId && selectedMenuId) {
-      // 서버 500에러로 테스트 불가
       updateMenu(menuId, menuForm?.getFieldsValue());
     }
     if (selectedMenuId === menuId) {
@@ -37,7 +35,6 @@ export default function MenuList({ form }: { form: FormInstance }) {
       <CustomForm
         labelCol={{ span: 6 }}
         wrapperCol={{ span: 18 }}
-        form={form}
         autoComplete="off"
         initialValues={menuList}
       >

--- a/src/pages/Services/Store/components/useMenuMutation.tsx
+++ b/src/pages/Services/Store/components/useMenuMutation.tsx
@@ -24,8 +24,8 @@ export default function useMenuMutation(id:number) {
     return updateMenuMutation({ id, menuId, menuData: body })
       .unwrap()
       .then(() => {})
-      .catch(({ data }) => {
-        message.error(data.message);
+      .catch(() => {
+        message.error('메뉴 수정에 실패했습니다.');
       });
   }
 


### PR DESCRIPTION
## 상점 메뉴 사진 업로드 오류 수정
- `useLayoutEffect` 사용으로 재렌더링 되지 않아 생긴 데이터 fetching 문제를 해결했습니다.

![image](https://github.com/BCSDLab/KOIN_ADMIN_V2/assets/101982606/85a89fc5-b312-49b7-b454-17184126061d)
![image](https://github.com/BCSDLab/KOIN_ADMIN_V2/assets/101982606/2f9c9d22-476a-4107-90e5-825dfb43382e)

