### PR TITLE
hotfix: 기본정보 require 추가 및 휴무여부 초기화 설정

### DIFF
--- a/src/pages/Services/Store/components/AddStoreModal.tsx
+++ b/src/pages/Services/Store/components/AddStoreModal.tsx
@@ -4,11 +4,13 @@ import CustomForm from 'components/common/CustomForm';
 
 import { message } from 'antd';
 import * as S from 'styles/List.style';
-import { StoreResponse } from 'model/store.model';
+import { DAY, StoreResponse } from 'model/store.model';
 import STORE_OPTION from 'constant/store';
 import { useEffect } from 'react';
 import useStoreMutation from './useStoreMutation';
 import StoreDetailForm from './StoreDetailForm';
+
+const DAYS = ['월', '화', '수', '목', '금', '토', '일'];
 
 export default function AddStoreModal({ closeModal }: { closeModal: () => void }) {
   const [form] = CustomForm.useForm();
@@ -20,9 +22,17 @@ export default function AddStoreModal({ closeModal }: { closeModal: () => void }
     ));
   }, [form]);
 
+  const defaultTimeInfo = DAYS.map((day, index) => {
+    return (
+      {
+        close_time: '00:00',
+        closed: false,
+        day_of_week: DAY[index],
+        open_time: '00:00',
+      });
+  });
+
   const createStore = (values: Partial<StoreResponse>) => {
-    // open 데이터 fetching 예외 처리
-    values.open = form.getFieldValue('open');
     addStore(values, {
       onSuccess: () => {
         message.success('정보 추가가 완료되었습니다.');
@@ -44,6 +54,7 @@ export default function AddStoreModal({ closeModal }: { closeModal: () => void }
     <CustomForm
       onFinish={createStore}
       form={form}
+      initialValues={{ open: defaultTimeInfo }}
     >
       <S.DetailFormWrap>
         <StoreDetailForm form={form} />

--- a/src/pages/Services/Store/components/OpenTimeForm.tsx
+++ b/src/pages/Services/Store/components/OpenTimeForm.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import { Divider, Select, TimePicker } from 'antd';
 import { FormInstance } from 'antd/es/form/Form';
-import { DAY, StoreOpen } from 'model/store.model';
+import { StoreOpen } from 'model/store.model';
 import { useState } from 'react';
 import CustomForm from 'components/common/CustomForm';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
@@ -25,22 +25,13 @@ const TABLE_TYPES = {
   },
 };
 
-const defaultTimeInfo = DAYS.map((day, index) => {
-  return (
-    {
-      close_time: '00:00',
-      closed: false,
-      day_of_week: DAY[index],
-      open_time: '00:00',
-    });
-});
-
 dayjs.extend(customParseFormat);
 
 function OpenTimeForm({ form }: { form: FormInstance }) {
-  const openTimeInfo: StoreOpen[] = form.getFieldValue('open') || defaultTimeInfo;
+  const openTimeInfo: StoreOpen[] = form.getFieldValue('open');
   const [selectType, setSelectType] = useState<keyof typeof TABLE_TYPES>('직접 지정');
   const newOpenTimeInfo = [...openTimeInfo];
+
   const handleTimeFormChange = (index: number, key: keyof StoreOpen, value: string | string[]) => {
     const selected = TABLE_TYPES[selectType];
     for (let i = 0; i < selected.colSize[index]; i += 1) {

--- a/src/pages/Services/Store/components/StoreDetailForm.tsx
+++ b/src/pages/Services/Store/components/StoreDetailForm.tsx
@@ -22,10 +22,10 @@ export default function StoreDetailForm({ form }: { form: FormInstance }) {
             required,
             pattern(/^[0-9]{3}-[0-9]{3,4}-[0-9]{4}$/, '전화번호 형식을 맞춰주세요')]}
         />
-        <CustomForm.InputNumber label="배달비" name="delivery_price" />
+        <CustomForm.InputNumber label="배달비" name="delivery_price" rules={[required]} />
       </CustomForm.GridRow>
       <CustomForm.Input label="주소" name="address" rules={[max(65535), required]} />
-      <CustomForm.TextArea label="설명" name="description" maxLength={200} />
+      <CustomForm.TextArea label="설명" name="description" maxLength={200} rules={[required]} />
       <CustomForm.Input label="카테고리 목록" name="category_ids" disabled rules={[required]} />
       <StoreCategory form={form} />
       <OpenTimeForm form={form} />


### PR DESCRIPTION
* 이슈 관련 사진
![image](https://github.com/BCSDLab/KOIN_ADMIN_V2/assets/86779590/b0067bf2-ce6d-4e76-b65b-4ddb9fddc43a)

어드민 페이지에서 상점들 등록 시 open과 관련된 속성이 페이로드에 담기지 않는 이슈를 해결하였습니다.
 => 이는 form의 입력 초기값에 기초 open 값을 넣는 방식으로 해결했습니다
 
추가적으로 [기본정보] 입력 파트에서 또다른 필수값인 설명, 배달비에 require 속성을 추가하여 필수 입력값이 되도록 하였습니다.

* require값이 수정된 기본정보 입력
<img width="787" alt="image" src="https://github.com/BCSDLab/KOIN_ADMIN_V2/assets/86779590/37501333-282a-4df9-8155-4ab8348738b0">
