### PR TITLE
[리뷰 관리] 리뷰 관리 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import OwnerList from 'pages/UserManage/Owner/OwnerList';
 import OwnerRequestList from 'pages/UserManage/OwnerRequest/OwnerRequestList';
 import OwnerRequestDetail from 'pages/UserManage/OwnerRequest/OwnerRequestDetail';
 import OwnerDetail from 'pages/UserManage/Owner/OwnerDetail';
+import ReviewList from 'pages/Services/Review/ReviewList';
 
 function RequireAuth() {
   const location = useLocation();
@@ -56,6 +57,7 @@ function App() {
         <Route path="/owner-request/:id" element={<OwnerRequestDetail />} />
         <Route path="/member" element={<MemberList />} />
         <Route path="/member/:id" element={<MemberDetail />} />
+        <Route path="/review" element={<ReviewList />} />
         <Route path="*" element={<h1>404</h1>} />
       </Route>
     </Routes>

--- a/src/components/common/ScrollUpButton/ScrollUpButton.tsx
+++ b/src/components/common/ScrollUpButton/ScrollUpButton.tsx
@@ -1,0 +1,22 @@
+import { UpCircleOutlined } from '@ant-design/icons';
+import styled from 'styled-components';
+
+const RightDownButton = styled.div`
+  position: fixed;
+  bottom: 100px;
+  right: 100px;
+  font-size: 40px;
+  cursor: pointer;
+`;
+
+export default function ScrollUpButton() {
+  const scrollUp = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  return (
+    <RightDownButton onClick={scrollUp}>
+      <UpCircleOutlined />
+    </RightDownButton>
+  );
+}

--- a/src/components/common/SideNav/index.tsx
+++ b/src/components/common/SideNav/index.tsx
@@ -2,7 +2,7 @@ import {
   AppstoreOutlined, UserOutlined, CarOutlined, ShopOutlined,
   HomeOutlined, UserSwitchOutlined,
   UsergroupDeleteOutlined, FolderOpenOutlined, ControlOutlined,
-  UserAddOutlined, BoldOutlined,
+  UserAddOutlined, BoldOutlined, SnippetsOutlined,
 } from '@ant-design/icons';
 import { Menu, MenuProps } from 'antd';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
@@ -31,6 +31,7 @@ const items: MenuProps['items'] = [
     getItem('주변상점', 'service-store', <ShopOutlined />, [
       getItem('상점 관리', '/store', <ControlOutlined />),
       getItem('카테고리', '/category', <FolderOpenOutlined />),
+      getItem('리뷰 관리', '/review', <SnippetsOutlined />),
     ]),
     getItem('버스 정보', '/bus', <CarOutlined />),
     getItem('복덕방', '/room', <HomeOutlined />),

--- a/src/constant/index.ts
+++ b/src/constant/index.ts
@@ -2,6 +2,8 @@ export const API_PATH = process.env.REACT_APP_API_PATH;
 
 export const SECOND_PASSWORD = process.env.REACT_APP_SECOND_PASSWORD;
 
+export const KOIN_URL = process.env.REACT_APP_API_PATH?.includes('stage') ? 'https://stage.koreatech.in' : 'https://koreatech.in';
+
 // 테이블 헤더 Title 매핑
 export const TITLE_MAPPER: Record<string, string> = {
   id: 'ID',

--- a/src/model/review.model.ts
+++ b/src/model/review.model.ts
@@ -38,6 +38,7 @@ export interface GetReviewListParam {
 
 export interface SetReviewParam {
   id: number;
+  page: number;
   body: {
     report_status: string
   }

--- a/src/model/review.model.ts
+++ b/src/model/review.model.ts
@@ -1,0 +1,44 @@
+export interface ReviewListResponse {
+  total_count: number,
+  current_count: number,
+  current_page: number,
+  reviews: ReviewContent[]
+}
+
+export interface ReviewContent {
+  reviewId: number,
+  rating: number,
+  nickName: string,
+  content: string,
+  imageUrls: string[],
+  menuNames: string[],
+  isModified: boolean,
+  isHaveUnhandledReport: boolean,
+  createdAt: string,
+  reports: ReportedReviewContent[]
+  shop: {
+    shopId: number,
+    shopName: string,
+  }
+}
+
+export interface ReportedReviewContent {
+  reportId: number,
+  title: string,
+  content: string,
+  nickName: string,
+  status: string,
+}
+
+export interface GetReviewListParam {
+  page: number;
+  limit: number;
+  isReported: boolean;
+}
+
+export interface SetReviewParam {
+  id: number;
+  body: {
+    report_status: string
+  }
+}

--- a/src/pages/Services/Review/ReviewCard.style.tsx
+++ b/src/pages/Services/Review/ReviewCard.style.tsx
@@ -14,10 +14,6 @@ export const Container = styled.div<{ $isHandle: boolean }>`
   transition: scale 0.3s, height 0.3s;
   width: 100%;
   gap: 10px;
-
-  &:hover {
-    scale: 1.015;
-  }
 `;
 
 export const Row = styled.div`

--- a/src/pages/Services/Review/ReviewCard.style.tsx
+++ b/src/pages/Services/Review/ReviewCard.style.tsx
@@ -1,0 +1,61 @@
+import styled from 'styled-components';
+
+export const Shortcut = styled.a`
+  color: '#cacaca';
+  text-decoration: none;
+`;
+
+export const Container = styled.div<{ $isHandle: boolean }>`
+  display: flex;
+  flex-direction: column;
+  padding: 10px 15px;
+  background: ${(props) => (props.$isHandle ? '#ff000050' : '#00BFFF10')};
+  border-radius: 10px;
+  transition: scale 0.3s, height 0.3s;
+  width: 100%;
+  gap: 10px;
+
+  &:hover {
+    scale: 1.015;
+  }
+`;
+
+export const Row = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const RowItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 20px;
+`;
+
+export const Item = styled.div`
+  width: 150px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+`;
+
+export const ToggleButton = styled.button`
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  height: 30px;
+`;
+
+export const MenuImage = styled.img`
+  width: 250px;
+  height: 250px;
+  object-fit: cover;
+  border-radius: 10px;
+`;
+
+export const AroundRow = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;

--- a/src/pages/Services/Review/ReviewCard.style.tsx
+++ b/src/pages/Services/Review/ReviewCard.style.tsx
@@ -5,11 +5,11 @@ export const Shortcut = styled.a`
   text-decoration: none;
 `;
 
-export const Container = styled.div<{ $isHandle: boolean }>`
+export const Container = styled.div<{ isHandle: boolean }>`
   display: flex;
   flex-direction: column;
   padding: 10px 15px;
-  background: ${(props) => (props.$isHandle ? '#ff000050' : '#00BFFF10')};
+  background: ${(props) => (props.isHandle ? '#ff000050' : '#00BFFF10')};
   border-radius: 10px;
   transition: scale 0.3s, height 0.3s;
   width: 100%;

--- a/src/pages/Services/Review/ReviewCard.tsx
+++ b/src/pages/Services/Review/ReviewCard.tsx
@@ -3,14 +3,13 @@ import { Button, message, Modal } from 'antd';
 import { useState } from 'react';
 import { CaretUpOutlined, CaretDownOutlined } from '@ant-design/icons';
 import { useDeleteReviewMutation, useSetReviewDismissedMutation } from 'store/api/review';
+import { KOIN_URL } from 'constant';
 import * as S from './ReviewCard.style';
 
 interface Props {
   review: ReviewContent;
   currentPage: number;
 }
-
-const KOIN_URL = process.env.REACT_APP_API_PATH?.includes('stage') ? 'https://stage.koreatech.in' : 'https://koreatech.in';
 
 export default function ReviewCard({ review, currentPage }: Props) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -54,7 +53,7 @@ export default function ReviewCard({ review, currentPage }: Props) {
   };
 
   return (
-    <S.Container $isHandle={review.isHaveUnhandledReport}>
+    <S.Container isHandle={review.isHaveUnhandledReport}>
       <S.Row>
         <S.RowItem>
           <S.Item>

--- a/src/pages/Services/Review/ReviewCard.tsx
+++ b/src/pages/Services/Review/ReviewCard.tsx
@@ -1,0 +1,189 @@
+import { ReviewContent } from 'model/review.model';
+import { Button, message, Modal } from 'antd';
+import { useState } from 'react';
+import { CaretUpOutlined, CaretDownOutlined } from '@ant-design/icons';
+import { useDeleteReviewMutation, useSetReviewDismissedMutation } from 'store/api/review';
+import * as S from './ReviewCard.style';
+
+interface Props {
+  review: ReviewContent
+}
+
+const KOIN_URL = process.env.REACT_APP_API_PATH?.includes('stage') ? 'https://stage.koreatech.in' : 'https://koreatech.in';
+
+export default function ReviewCard({ review }: Props) {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [isReportOpen, setIsReportOpen] = useState<boolean>(false);
+  const toggle = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  const [deleteReview, {
+    isLoading: isDeleteLoading,
+    isError: isDeleteError,
+  }] = useDeleteReviewMutation();
+  const [dismissReview, {
+    isLoading: isDismissLoading,
+    isError: isDismissError,
+  }] = useSetReviewDismissedMutation();
+
+  if (isDeleteError) {
+    message.error('리뷰 삭제에 실패했습니다');
+  }
+  if (isDismissError) {
+    message.error('리뷰 상태 변경에 실패했습니다.');
+  }
+
+  const deleteSpecificReview = () => {
+    deleteReview(review.reviewId);
+  };
+
+  const dismissSpecificReview = () => {
+    dismissReview({
+      id: review.reviewId,
+      body: {
+        report_status: 'DISMISSED',
+      },
+    });
+  };
+
+  return (
+    <S.Container $isHandle={review.isHaveUnhandledReport}>
+      <S.Row>
+        <S.RowItem>
+          <S.Item>
+            {review.shop.shopName}
+          </S.Item>
+          <S.Item>
+            {review.createdAt}
+          </S.Item>
+        </S.RowItem>
+        <S.RowItem>
+          <S.Item>
+            <S.Shortcut href={`${KOIN_URL}/store/${review.shop.shopId}?state=리뷰`} target="_blank" rel="noreferrer">식당 페이지 바로가기</S.Shortcut>
+          </S.Item>
+          <S.Item>
+            <Button
+              danger
+              disabled={isDeleteLoading}
+              onClick={() => setIsModalOpen(true)}
+            >
+              삭제하기
+            </Button>
+          </S.Item>
+        </S.RowItem>
+      </S.Row>
+      <S.Row>
+        <S.RowItem>
+          <S.Item>
+            별점:
+            {' '}
+            {review.rating}
+          </S.Item>
+          {!isOpen && (
+            <S.Item>
+              {review.content}
+            </S.Item>
+          )}
+        </S.RowItem>
+      </S.Row>
+      {isOpen && (
+        <>
+          <S.Row>
+            <div>
+              리뷰 내용:
+              {' '}
+              {review.content}
+            </div>
+          </S.Row>
+          <S.Row>
+            <div>
+              사진:
+              {' '}
+              {review.imageUrls.length > 0 ? review.imageUrls.map((image) => (
+                <S.MenuImage
+                  src={image}
+                  key={image}
+                  loading="lazy"
+                  alt="리뷰 이미지"
+                />
+              )) : '없음'}
+            </div>
+          </S.Row>
+          <S.Row>
+            <div>
+              이용 메뉴:
+              {' '}
+              {review.menuNames.length > 0 ? review.menuNames.map((menu) => <div key={menu}>{menu}</div>) : '미기재'}
+            </div>
+          </S.Row>
+          <S.Row>
+            <div>
+              수정이력:
+              {' '}
+              {review.isModified ? 'O' : 'X'}
+            </div>
+          </S.Row>
+          <S.AroundRow>
+            <S.Item>
+              {review.isHaveUnhandledReport ? '신고정보' : '신고이력'}
+            </S.Item>
+          </S.AroundRow>
+          {review.reports.length > 0
+            ? (
+              <S.Row>
+                <S.Item>
+                  <Button onClick={() => setIsReportOpen(true)}>확인하기</Button>
+                </S.Item>
+                {review.isHaveUnhandledReport
+                  && (
+                    <S.Item>
+                      <Button
+                        onClick={dismissSpecificReview}
+                        disabled={isDismissLoading}
+                      >
+                        유지하기
+                      </Button>
+                    </S.Item>
+                  )}
+              </S.Row>
+
+            ) : '없음'}
+        </>
+      )}
+      <S.ToggleButton type="button" onClick={toggle}>
+        {isOpen ? <CaretUpOutlined /> : <CaretDownOutlined />}
+      </S.ToggleButton>
+      <Modal open={isModalOpen} footer={null} onCancel={() => setIsModalOpen(false)}>
+        <S.AroundRow>
+          정말로 삭제하시겠습니까?
+          <S.Item>
+            <Button
+              danger
+              onClick={() => {
+                deleteSpecificReview();
+                setIsModalOpen(false);
+              }}
+            >
+              삭제
+            </Button>
+            <Button onClick={() => setIsModalOpen(false)}>취소</Button>
+          </S.Item>
+        </S.AroundRow>
+      </Modal>
+      <Modal open={isReportOpen} onCancel={() => setIsReportOpen(false)} footer={null}>
+        {review.reports.map((report, idx) => (
+          <S.Row
+            key={report.reportId}
+          >
+            {idx + 1}
+            .
+            {' '}
+            {report.content}
+          </S.Row>
+        ))}
+      </Modal>
+    </S.Container>
+  );
+}

--- a/src/pages/Services/Review/ReviewCard.tsx
+++ b/src/pages/Services/Review/ReviewCard.tsx
@@ -6,12 +6,13 @@ import { useDeleteReviewMutation, useSetReviewDismissedMutation } from 'store/ap
 import * as S from './ReviewCard.style';
 
 interface Props {
-  review: ReviewContent
+  review: ReviewContent;
+  currentPage: number;
 }
 
 const KOIN_URL = process.env.REACT_APP_API_PATH?.includes('stage') ? 'https://stage.koreatech.in' : 'https://koreatech.in';
 
-export default function ReviewCard({ review }: Props) {
+export default function ReviewCard({ review, currentPage }: Props) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [isReportOpen, setIsReportOpen] = useState<boolean>(false);
@@ -36,7 +37,10 @@ export default function ReviewCard({ review }: Props) {
   }
 
   const deleteSpecificReview = () => {
-    deleteReview(review.reviewId);
+    deleteReview({
+      id: review.reviewId,
+      page: currentPage,
+    });
   };
 
   const dismissSpecificReview = () => {

--- a/src/pages/Services/Review/ReviewCard.tsx
+++ b/src/pages/Services/Review/ReviewCard.tsx
@@ -46,6 +46,7 @@ export default function ReviewCard({ review, currentPage }: Props) {
   const dismissSpecificReview = () => {
     dismissReview({
       id: review.reviewId,
+      page: currentPage,
       body: {
         report_status: 'DISMISSED',
       },

--- a/src/pages/Services/Review/ReviewList.style.tsx
+++ b/src/pages/Services/Review/ReviewList.style.tsx
@@ -7,6 +7,7 @@ export const Container = styled.div`
   flex-direction: column;
   box-sizing: border-box;
   gap: 30px;
+  position: relative;
 `;
 
 export const Filter = styled.div`
@@ -21,4 +22,12 @@ export const DataContainer = styled.div`
   flex-direction: column;
   gap: 15px;
   width: 100%;
+`;
+
+export const RightDownButton = styled.div`
+  position: fixed;
+  bottom: 100px;
+  right: 100px;
+  font-size: 40px;
+  cursor: pointer;
 `;

--- a/src/pages/Services/Review/ReviewList.style.tsx
+++ b/src/pages/Services/Review/ReviewList.style.tsx
@@ -22,6 +22,7 @@ export const DataContainer = styled.div`
   flex-direction: column;
   gap: 15px;
   width: 100%;
+  margin-bottom: 30px;
 `;
 
 export const RightDownButton = styled.div`

--- a/src/pages/Services/Review/ReviewList.style.tsx
+++ b/src/pages/Services/Review/ReviewList.style.tsx
@@ -24,11 +24,3 @@ export const DataContainer = styled.div`
   width: 100%;
   margin-bottom: 30px;
 `;
-
-export const RightDownButton = styled.div`
-  position: fixed;
-  bottom: 100px;
-  right: 100px;
-  font-size: 40px;
-  cursor: pointer;
-`;

--- a/src/pages/Services/Review/ReviewList.style.tsx
+++ b/src/pages/Services/Review/ReviewList.style.tsx
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  height: 100vh;
+  min-width: 1000px;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  gap: 30px;
+`;
+
+export const Filter = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 15px;
+`;
+
+export const DataContainer = styled.div`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  gap: 15px;
+  width: 100%;
+`;

--- a/src/pages/Services/Review/ReviewList.tsx
+++ b/src/pages/Services/Review/ReviewList.tsx
@@ -1,7 +1,5 @@
-import { Checkbox, Skeleton } from 'antd';
-import {
-  useEffect, useRef, useState,
-} from 'react';
+import { Checkbox, Skeleton, Pagination } from 'antd';
+import { useState } from 'react';
 import { useGetReviewListQuery } from 'store/api/review';
 import * as Common from 'styles/List.style';
 import { UpCircleOutlined } from '@ant-design/icons';
@@ -14,9 +12,8 @@ export default function ReviewList() {
   const [page, setPage] = useState(1);
   const [isReported, setIsReported] = useState<boolean>(false);
   const {
-    data, isLoading, isFetching,
+    data, isLoading,
   } = useGetReviewListQuery({ page, limit: LIMIT, isReported });
-  const endOfPage = useRef<HTMLDivElement>(null);
 
   const scrollUp = () => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -26,26 +23,6 @@ export default function ReviewList() {
     setIsReported((prev) => !prev);
     setPage(1);
   };
-
-  useEffect(() => {
-    const getNextPage = (entries: IntersectionObserverEntry[]) => {
-      if (entries[0].isIntersecting
-        && data && data.total_count > LIMIT * page
-        && !isLoading && !isFetching) {
-        setPage((prev) => prev + 1);
-      }
-    };
-
-    const observer = new IntersectionObserver(getNextPage);
-
-    if (endOfPage.current) {
-      observer.observe(endOfPage.current);
-    }
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [data, isLoading, page, isFetching]);
 
   return (
     <S.Container>
@@ -63,9 +40,16 @@ export default function ReviewList() {
               <ReviewCard
                 review={review}
                 key={review.reviewId}
+                currentPage={page}
               />
             ))}
-            <div ref={endOfPage} style={{ height: '100px' }} />
+            {data && (
+            <Pagination
+              total={Math.round(data.total_count / 10) * 10}
+              current={page}
+              onChange={(num) => setPage(num)}
+            />
+            )}
           </S.DataContainer>
         </>
       )}

--- a/src/pages/Services/Review/ReviewList.tsx
+++ b/src/pages/Services/Review/ReviewList.tsx
@@ -1,0 +1,69 @@
+import { Checkbox, Skeleton } from 'antd';
+import {
+  useEffect, useRef, useState,
+} from 'react';
+import { useGetReviewListQuery } from 'store/api/review';
+import * as Common from 'styles/List.style';
+import ReviewCard from './ReviewCard';
+import * as S from './ReviewList.style';
+
+const LIMIT = 10;
+
+export default function ReviewList() {
+  const [page, setPage] = useState(1);
+  const [isReported, setIsReported] = useState<boolean>(false);
+  const {
+    data, isLoading, isFetching,
+  } = useGetReviewListQuery({ page, limit: LIMIT, isReported });
+  const endOfPage = useRef<HTMLDivElement>(null);
+
+  const filterReportedReview = () => {
+    setIsReported((prev) => !prev);
+    setPage(1);
+  };
+
+  useEffect(() => {
+    const getNextPage = (entries: IntersectionObserverEntry[]) => {
+      if (entries[0].isIntersecting
+        && data && data.total_count > LIMIT * page
+        && !isLoading && !isFetching) {
+        setPage((prev) => prev + 1);
+      }
+    };
+
+    const observer = new IntersectionObserver(getNextPage);
+
+    if (endOfPage.current) {
+      observer.observe(endOfPage.current);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [data, isLoading, page, isFetching]);
+
+  return (
+    <S.Container>
+      <Common.Heading>
+        리뷰 목록
+      </Common.Heading>
+      {isLoading ? [1, 2, 3, 4, 5].map((key) => <Skeleton key={key} active />) : (
+        <>
+          <S.Filter>
+            <Checkbox checked={!!isReported} onChange={filterReportedReview} />
+            신고된 리뷰만 모아보기
+          </S.Filter>
+          <S.DataContainer>
+            {data && data.reviews.map((review) => (
+              <ReviewCard
+                review={review}
+                key={review.reviewId}
+              />
+            ))}
+            <div ref={endOfPage} style={{ height: '100px' }} />
+          </S.DataContainer>
+        </>
+      )}
+    </S.Container>
+  );
+}

--- a/src/pages/Services/Review/ReviewList.tsx
+++ b/src/pages/Services/Review/ReviewList.tsx
@@ -2,7 +2,7 @@ import { Checkbox, Skeleton, Pagination } from 'antd';
 import { useState } from 'react';
 import { useGetReviewListQuery } from 'store/api/review';
 import * as Common from 'styles/List.style';
-import { UpCircleOutlined } from '@ant-design/icons';
+import ScrollUpButton from 'components/common/ScrollUpButton/ScrollUpButton';
 import ReviewCard from './ReviewCard';
 import * as S from './ReviewList.style';
 
@@ -14,10 +14,6 @@ export default function ReviewList() {
   const {
     data, isLoading,
   } = useGetReviewListQuery({ page, limit: LIMIT, isReported });
-
-  const scrollUp = () => {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
-  };
 
   const filterReportedReview = () => {
     setIsReported((prev) => !prev);
@@ -32,7 +28,7 @@ export default function ReviewList() {
       {isLoading ? [1, 2, 3, 4, 5].map((key) => <Skeleton key={key} active />) : (
         <>
           <S.Filter>
-            <Checkbox checked={!!isReported} onChange={filterReportedReview} />
+            <Checkbox checked={isReported} onChange={filterReportedReview} />
             신고된 리뷰만 모아보기
           </S.Filter>
           <S.DataContainer>
@@ -55,9 +51,7 @@ export default function ReviewList() {
           </S.DataContainer>
         </>
       )}
-      <S.RightDownButton onClick={scrollUp}>
-        <UpCircleOutlined />
-      </S.RightDownButton>
+      <ScrollUpButton />
     </S.Container>
   );
 }

--- a/src/pages/Services/Review/ReviewList.tsx
+++ b/src/pages/Services/Review/ReviewList.tsx
@@ -44,11 +44,13 @@ export default function ReviewList() {
               />
             ))}
             {data && (
-            <Pagination
-              total={Math.round(data.total_count / 10) * 10}
-              current={page}
-              onChange={(num) => setPage(num)}
-            />
+              <S.DataContainer>
+                <Pagination
+                  total={data.total_count}
+                  current={page}
+                  onChange={(num) => setPage(num)}
+                />
+              </S.DataContainer>
             )}
           </S.DataContainer>
         </>

--- a/src/pages/Services/Review/ReviewList.tsx
+++ b/src/pages/Services/Review/ReviewList.tsx
@@ -4,6 +4,7 @@ import {
 } from 'react';
 import { useGetReviewListQuery } from 'store/api/review';
 import * as Common from 'styles/List.style';
+import { UpCircleOutlined } from '@ant-design/icons';
 import ReviewCard from './ReviewCard';
 import * as S from './ReviewList.style';
 
@@ -16,6 +17,10 @@ export default function ReviewList() {
     data, isLoading, isFetching,
   } = useGetReviewListQuery({ page, limit: LIMIT, isReported });
   const endOfPage = useRef<HTMLDivElement>(null);
+
+  const scrollUp = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
 
   const filterReportedReview = () => {
     setIsReported((prev) => !prev);
@@ -64,6 +69,9 @@ export default function ReviewList() {
           </S.DataContainer>
         </>
       )}
+      <S.RightDownButton onClick={scrollUp}>
+        <UpCircleOutlined />
+      </S.RightDownButton>
     </S.Container>
   );
 }

--- a/src/store/api/review/index.ts
+++ b/src/store/api/review/index.ts
@@ -21,18 +21,7 @@ export const reviewApi = createApi({
   endpoints: (builder) => ({
     getReviewList: builder.query<ReviewListResponse, GetReviewListParam>({
       query: ({ page, limit, isReported }) => ({ url: `admin/shops/reviews?page=${page}&limit=${limit}&${isReported ? 'is_reported=true' : ''}` }),
-      providesTags: () => [{ type: 'reviews' }],
-      serializeQueryArgs: ({ queryArgs }) => {
-        return `${queryArgs.isReported}`; // 캐시 키를 `isReported` 값을 포함하도록 수정
-      },
-      merge: (cached, newItem, { arg }) => {
-        if (arg.page === 1) return newItem;
-        cached.reviews.push(...newItem.reviews);
-        return cached;
-      },
-      forceRefetch({ currentArg, previousArg }) {
-        return currentArg?.page !== previousArg?.page;
-      },
+      providesTags: (result, error, { page }) => [{ type: 'reviews', id: page }],
     }),
 
     setReviewDismissed: builder.mutation<string, SetReviewParam>({
@@ -46,14 +35,14 @@ export const reviewApi = createApi({
       invalidatesTags: [{ type: 'reviews' }],
     }),
 
-    deleteReview: builder.mutation<void, number>({
-      query(id) {
+    deleteReview: builder.mutation<void, { id: number, page: number }>({
+      query({ id }) {
         return {
           url: `/admin/shops/reviews/${id}`,
           method: 'delete',
         };
       },
-      invalidatesTags: [{ type: 'reviews' }],
+      invalidatesTags: (result, error, { page }) => [{ type: 'reviews', id: page }],
     }),
   }),
 });

--- a/src/store/api/review/index.ts
+++ b/src/store/api/review/index.ts
@@ -1,0 +1,63 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { API_PATH } from 'constant';
+import { GetReviewListParam, ReviewListResponse, SetReviewParam } from 'model/review.model';
+import { RootState } from 'store';
+
+export const reviewApi = createApi({
+  reducerPath: 'reviews',
+  tagTypes: ['reviews'],
+
+  baseQuery: fetchBaseQuery({
+    baseUrl: `${API_PATH}`,
+    prepareHeaders: (headers, { getState }) => {
+      const { token } = (getState() as RootState).auth;
+      if (token) {
+        headers.set('authorization', `Bearer ${token}`);
+      }
+      return headers;
+    },
+  }),
+
+  endpoints: (builder) => ({
+    getReviewList: builder.query<ReviewListResponse, GetReviewListParam>({
+      query: ({ page, limit, isReported }) => ({ url: `admin/shops/reviews?page=${page}&limit=${limit}&${isReported ? 'is_reported=true' : ''}` }),
+      providesTags: () => [{ type: 'reviews' }],
+      serializeQueryArgs: ({ queryArgs }) => {
+        return `${queryArgs.isReported}`; // 캐시 키를 `isReported` 값을 포함하도록 수정
+      },
+      merge: (cached, newItem, { arg }) => {
+        if (arg.page === 1) return newItem;
+        cached.reviews.push(...newItem.reviews);
+        return cached;
+      },
+      forceRefetch({ currentArg, previousArg }) {
+        return currentArg?.page !== previousArg?.page;
+      },
+    }),
+
+    setReviewDismissed: builder.mutation<string, SetReviewParam>({
+      query({ id, body }) {
+        return {
+          url: `admin/shops/reviews/${id}`,
+          method: 'put',
+          body,
+        };
+      },
+      invalidatesTags: [{ type: 'reviews' }],
+    }),
+
+    deleteReview: builder.mutation<void, number>({
+      query(id) {
+        return {
+          url: `/admin/shops/reviews/${id}`,
+          method: 'delete',
+        };
+      },
+      invalidatesTags: [{ type: 'reviews' }],
+    }),
+  }),
+});
+
+export const {
+  useGetReviewListQuery, useSetReviewDismissedMutation, useDeleteReviewMutation,
+} = reviewApi;

--- a/src/store/api/review/index.ts
+++ b/src/store/api/review/index.ts
@@ -32,7 +32,7 @@ export const reviewApi = createApi({
           body,
         };
       },
-      invalidatesTags: [{ type: 'reviews' }],
+      invalidatesTags: (result, error, { page }) => [{ type: 'reviews', id: page }],
     }),
 
     deleteReview: builder.mutation<void, { id: number, page: number }>({

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -11,6 +11,7 @@ import { storeMenuApi } from './api/storeMenu';
 import { menuCategoriesApi } from './api/storeMenu/category';
 import { ownerRequestApi } from './api/ownerRequest';
 import { ownerApi } from './api/owner';
+import { reviewApi } from './api/review';
 
 const apiList = [
   authApi,
@@ -24,6 +25,7 @@ const apiList = [
   menuCategoriesApi,
   ownerRequestApi,
   ownerApi,
+  reviewApi,
 ];
 
 const apiMiddleware = apiList.map((api) => api.middleware);


### PR DESCRIPTION
리뷰 관리 기능을 추가했습니다.
코인 - 주변상점 - 리뷰탭에 존재하는 리뷰를 관리하는 페이지입니다.

1. 모든 리뷰를 모니터링하고 필요에 따라 삭제할 수 있습니다.
2. 신고된 리뷰만 모아서 확인할 수 있습니다.
3. 리뷰 신고를 reject할 수 있습니다

무한 스크롤로 구현하려 했으나, rtk query를 사용해서 특정값의 캐시를 무효화하는 작업이 컨트롤하기 어려웠습니다.
serializeQueryArgs 를 통해 쿼리키를 직렬화하면 특정 태그를 무효화하는 작업이 컨트롤하기 어렵더라구요.. 피드백 받습니다

추후 리팩토링하겠습니다.

## Screen shot
![image](https://github.com/user-attachments/assets/808fb751-8574-41bd-a70d-96222a2f37fd)
