### PR TITLE
[Auth] 리프레시 토큰을 통한 액세스 토큰 갱신 로직 추가

### DIFF
--- a/src/model/auth.model.ts
+++ b/src/model/auth.model.ts
@@ -18,6 +18,7 @@ export interface User {
 
 export interface LoginResponse {
   token: string;
+  refresh_token: string;
 }
 
 export interface LoginState {

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -38,6 +38,7 @@ function useLogin() {
         const credentials = res.data;
         dispatch(setCredentials(credentials));
         sessionStorage.setItem('token', credentials.token);
+        localStorage.setItem('refresh_token', credentials.refresh_token);
       } else if ('error' in res) {
         message.error('올바른 계정이 아닙니다.');
       }

--- a/src/store/api/baseQueryReauth.ts
+++ b/src/store/api/baseQueryReauth.ts
@@ -30,7 +30,7 @@ FetchBaseQueryError
   let result = await baseQuery(args, api, extraOptions);
   const refreshToken = localStorage.getItem('refresh_token');
 
-  // 401 오류가 발생한다면 액세스 토큰 없음
+  // 401 오류가 발생한다면 액세스 토큰 만료일 가능성이 높음
   if (result.error && result.error.status === 401 && refreshToken) {
     // 리프레시 토큰을 통해 액세스 토큰을 재발급
     const refresh = await baseQuery(
@@ -54,6 +54,8 @@ FetchBaseQueryError
 
       // 액세스 토큰 갱신 후 다시 요청
       result = await baseQuery(args, api, extraOptions);
+    } else {
+      throw new Error('refresh failed');
     }
   }
 

--- a/src/store/api/baseQueryReauth.ts
+++ b/src/store/api/baseQueryReauth.ts
@@ -1,10 +1,9 @@
 import {
-  BaseQueryFn, createApi, FetchArgs, fetchBaseQuery, FetchBaseQueryError,
+  BaseQueryFn, FetchArgs, fetchBaseQuery, FetchBaseQueryError,
 } from '@reduxjs/toolkit/query/react';
-import { LoginRequest, LoginResponse } from 'model/auth.model';
-import { RootState } from 'store';
-import { API_PATH } from 'constant';
 import { setCredentials } from 'store/slice/auth';
+import { API_PATH } from 'constant';
+import { RootState } from 'store';
 
 interface RefreshResponse {
   refresh_token: string;
@@ -12,7 +11,7 @@ interface RefreshResponse {
 }
 
 const baseQuery = fetchBaseQuery({
-  baseUrl: `${API_PATH}/admin`,
+  baseUrl: `${API_PATH}`,
   prepareHeaders: (headers, { getState }) => {
     // 토큰이 필요한 조회에는 헤더를 추가할 필요가 있음.
     const { token } = (getState() as RootState).auth;
@@ -61,24 +60,4 @@ FetchBaseQueryError
   return result;
 };
 
-export const authApi = createApi({
-  baseQuery: baseQueryReauth,
-  endpoints: (builder) => ({
-    login: builder.mutation<LoginResponse, LoginRequest>({
-      query: ({ email, password }) => ({
-        url: '/user/login',
-        method: 'POST',
-        body: {
-          email: `${email}@koreatech.ac.kr`,
-          password,
-        },
-      }),
-    }),
-    // 요청 예시
-    protected: builder.mutation<{ message: string }, void>({
-      query: () => 'protected',
-    }),
-  }),
-});
-
-export const { useLoginMutation, useProtectedMutation } = authApi;
+export default baseQueryReauth;

--- a/src/store/api/category/index.ts
+++ b/src/store/api/category/index.ts
@@ -1,22 +1,12 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import { API_PATH } from 'constant';
+import { createApi } from '@reduxjs/toolkit/query/react';
 import { CategoriesResponse, Category } from 'model/category.model';
-import { RootState } from 'store';
+import baseQueryReauth from 'store/api/baseQueryReauth';
 
 export const categoryApi = createApi({
   reducerPath: 'category',
   tagTypes: ['categories', 'category'],
 
-  baseQuery: fetchBaseQuery({
-    baseUrl: `${API_PATH}`,
-    prepareHeaders: (headers, { getState }) => {
-      const { token } = (getState() as RootState).auth;
-      if (token) {
-        headers.set('authorization', `Bearer ${token}`);
-      }
-      return headers;
-    },
-  }),
+  baseQuery: baseQueryReauth,
 
   endpoints: (builder) => ({
     getCategoryList: builder.query<CategoriesResponse, { page: number, size?: number }>({

--- a/src/store/api/member/index.ts
+++ b/src/store/api/member/index.ts
@@ -1,23 +1,13 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import { RootState } from 'store';
-import { API_PATH } from 'constant';
+import { createApi } from '@reduxjs/toolkit/query/react';
 import {
   MemberTableHead, MembersParam, MembersResponse, Member,
 } from 'model/member.model';
+import baseQueryReauth from 'store/api/baseQueryReauth';
 
 export const memberApi = createApi({
   reducerPath: 'member',
   tagTypes: ['members', 'member'],
-  baseQuery: fetchBaseQuery({
-    baseUrl: `${API_PATH}`,
-    prepareHeaders: (headers, { getState }) => {
-      const { token } = (getState() as RootState).auth;
-      if (token) {
-        headers.set('authorization', `Bearer ${token}`);
-      }
-      return headers;
-    },
-  }),
+  baseQuery: baseQueryReauth,
   endpoints: (builder) => ({
     getMemberList: builder.query<{
       memberList: MemberTableHead[],

--- a/src/store/api/owner/index.ts
+++ b/src/store/api/owner/index.ts
@@ -1,23 +1,13 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import { RootState } from 'store';
-import { API_PATH } from 'constant';
+import { createApi } from '@reduxjs/toolkit/query/react';
 import {
   OwnerResponse, OwnersParam, OwnerListResponse, OwnersResponse,
 } from 'model/owner.model';
+import baseQueryReauth from 'store/api/baseQueryReauth';
 
 export const ownerApi = createApi({
   reducerPath: 'owner',
   tagTypes: ['owners', 'owner'],
-  baseQuery: fetchBaseQuery({
-    baseUrl: `${API_PATH}`,
-    prepareHeaders: (headers, { getState }) => {
-      const { token } = (getState() as RootState).auth;
-      if (token) {
-        headers.set('authorization', `Bearer ${token}`);
-      }
-      return headers;
-    },
-  }),
+  baseQuery: baseQueryReauth,
   endpoints: (builder) => ({
     getOwnerList: builder.query<OwnerListResponse, OwnersParam>({
       query: ({ page }) => `admin/users/owners?page=${page}`,

--- a/src/store/api/ownerRequest/index.ts
+++ b/src/store/api/ownerRequest/index.ts
@@ -1,23 +1,13 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import { RootState } from 'store';
-import { API_PATH } from 'constant';
+import { createApi } from '@reduxjs/toolkit/query/react';
 import {
   OwnerResponse, OwnerRequestListResponse, OwnersParam, OwnersResponse,
 } from 'model/owner.model';
+import baseQueryReauth from 'store/api/baseQueryReauth';
 
 export const ownerRequestApi = createApi({
   reducerPath: 'ownerRequest',
   tagTypes: ['ownerRequests', 'ownerRequest'],
-  baseQuery: fetchBaseQuery({
-    baseUrl: `${API_PATH}`,
-    prepareHeaders: (headers, { getState }) => {
-      const { token } = (getState() as RootState).auth;
-      if (token) {
-        headers.set('authorization', `Bearer ${token}`);
-      }
-      return headers;
-    },
-  }),
+  baseQuery: baseQueryReauth,
   endpoints: (builder) => ({
     getOwnerRequestList: builder.query<OwnerRequestListResponse, OwnersParam>({
       query: ({ page }) => `admin/users/new-owners?page=${page}`,

--- a/src/store/api/review/index.ts
+++ b/src/store/api/review/index.ts
@@ -1,22 +1,12 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import { API_PATH } from 'constant';
+import { createApi } from '@reduxjs/toolkit/query/react';
 import { GetReviewListParam, ReviewListResponse, SetReviewParam } from 'model/review.model';
-import { RootState } from 'store';
+import baseQueryReauth from 'store/api/baseQueryReauth';
 
 export const reviewApi = createApi({
   reducerPath: 'reviews',
   tagTypes: ['reviews'],
 
-  baseQuery: fetchBaseQuery({
-    baseUrl: `${API_PATH}`,
-    prepareHeaders: (headers, { getState }) => {
-      const { token } = (getState() as RootState).auth;
-      if (token) {
-        headers.set('authorization', `Bearer ${token}`);
-      }
-      return headers;
-    },
-  }),
+  baseQuery: baseQueryReauth,
 
   endpoints: (builder) => ({
     getReviewList: builder.query<ReviewListResponse, GetReviewListParam>({

--- a/src/store/api/room/index.ts
+++ b/src/store/api/room/index.ts
@@ -1,25 +1,15 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import { API_PATH } from 'constant';
+import { createApi } from '@reduxjs/toolkit/query/react';
 import {
   RoomParams,
   RoomResponse, RoomsResponse, RoomTableHead,
 } from 'model/room.model';
-import { RootState } from 'store';
+import baseQueryReauth from 'store/api/baseQueryReauth';
 
 export const roomApi = createApi({
   reducerPath: 'room',
   tagTypes: ['rooms', 'room'],
 
-  baseQuery: fetchBaseQuery({
-    baseUrl: `${API_PATH}`,
-    prepareHeaders: (headers, { getState }) => {
-      const { token } = (getState() as RootState).auth;
-      if (token) {
-        headers.set('authorization', `Bearer ${token}`);
-      }
-      return headers;
-    },
-  }),
+  baseQuery: baseQueryReauth,
 
   endpoints: (builder) => ({
     getRoomList: builder.query<{ roomList: RoomTableHead[], totalPage: number }, RoomParams>({

--- a/src/store/api/store/index.ts
+++ b/src/store/api/store/index.ts
@@ -1,25 +1,15 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import { API_PATH } from 'constant';
+import { createApi } from '@reduxjs/toolkit/query/react';
 import {
   StoreDetailForm,
   StoreParams, StoreResponse, StoreTransformResponse, StoresResponse,
 } from 'model/store.model';
-import { RootState } from 'store';
+import baseQueryReauth from 'store/api/baseQueryReauth';
 
 export const storeApi = createApi({
   reducerPath: 'storeApi',
   tagTypes: ['stores', 'store'],
 
-  baseQuery: fetchBaseQuery({
-    baseUrl: `${API_PATH}`,
-    prepareHeaders: (headers, { getState }) => {
-      const { token } = (getState() as RootState).auth;
-      if (token) {
-        headers.set('authorization', `Bearer ${token}`);
-      }
-      return headers;
-    },
-  }),
+  baseQuery: baseQueryReauth,
 
   endpoints: (builder) => ({
     getStoreList: builder.query<StoreTransformResponse, StoreParams>({

--- a/src/store/api/storeMenu/category.ts
+++ b/src/store/api/storeMenu/category.ts
@@ -1,23 +1,13 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import { API_PATH } from 'constant';
+import { createApi } from '@reduxjs/toolkit/query/react';
 import { MenuCategories } from 'model/menuCategory';
 import { MenuCategory } from 'model/menus.model';
-import { RootState } from 'store';
+import baseQueryReauth from 'store/api/baseQueryReauth';
 
 export const menuCategoriesApi = createApi({
   reducerPath: 'menuCategoriesApi',
   tagTypes: ['menuCategories'],
 
-  baseQuery: fetchBaseQuery({
-    baseUrl: `${API_PATH}`,
-    prepareHeaders: (headers, { getState }) => {
-      const { token } = (getState() as RootState).auth;
-      if (token) {
-        headers.set('authorization', `Bearer ${token}`);
-      }
-      return headers;
-    },
-  }),
+  baseQuery: baseQueryReauth,
 
   endpoints: (builder) => ({
     getMenuCategories: builder.query<MenuCategories, number>({

--- a/src/store/api/storeMenu/index.ts
+++ b/src/store/api/storeMenu/index.ts
@@ -1,25 +1,14 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import { API_PATH } from 'constant';
-
+import { createApi } from '@reduxjs/toolkit/query/react';
 import {
   MenusResponse, MenuResponse, MutationMenuArgs, Menu,
 } from 'model/menus.model';
-import { RootState } from 'store';
+import baseQueryReauth from 'store/api/baseQueryReauth';
 
 export const storeMenuApi = createApi({
   reducerPath: 'storeMenusApi',
   tagTypes: ['storeMenus', 'storeMenu'],
 
-  baseQuery: fetchBaseQuery({
-    baseUrl: `${API_PATH}`,
-    prepareHeaders: (headers, { getState }) => {
-      const { token } = (getState() as RootState).auth;
-      if (token) {
-        headers.set('authorization', `Bearer ${token}`);
-      }
-      return headers;
-    },
-  }),
+  baseQuery: baseQueryReauth,
 
   endpoints: (builder) => ({
     getMenusList: builder.query<MenusResponse, number>({

--- a/src/store/api/upload/index.ts
+++ b/src/store/api/upload/index.ts
@@ -1,23 +1,13 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import { RootState } from 'store';
-import { API_PATH } from 'constant';
+import { createApi } from '@reduxjs/toolkit/query/react';
 import {
   Upload, UploadResponse, Uploads, UploadsResponse,
 } from 'model/upload.model';
+import baseQueryReauth from 'store/api/baseQueryReauth';
 
 export const uploadApi = createApi({
   reducerPath: 'file',
   tagTypes: ['files', 'file'],
-  baseQuery: fetchBaseQuery({
-    baseUrl: `${API_PATH}`,
-    prepareHeaders: (headers, { getState }) => {
-      const { token } = (getState() as RootState).auth;
-      if (token) {
-        headers.set('authorization', `Bearer ${token}`);
-      }
-      return headers;
-    },
-  }),
+  baseQuery: baseQueryReauth,
   endpoints: (builder) => ({
     uploadfiles: builder.mutation<UploadsResponse, Uploads>({
       query({ domain, images }) {

--- a/src/store/api/user/index.ts
+++ b/src/store/api/user/index.ts
@@ -1,21 +1,11 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import { RootState } from 'store';
-import { API_PATH } from 'constant';
+import { createApi } from '@reduxjs/toolkit/query/react';
 import { UserDetail, UsersResponse, UserTableHead } from 'model/user.model';
+import baseQueryReauth from 'store/api/baseQueryReauth';
 
 export const userApi = createApi({
   reducerPath: 'user',
   tagTypes: ['users', 'user'],
-  baseQuery: fetchBaseQuery({
-    baseUrl: `${API_PATH}`,
-    prepareHeaders: (headers, { getState }) => {
-      const { token } = (getState() as RootState).auth;
-      if (token) {
-        headers.set('authorization', `Bearer ${token}`);
-      }
-      return headers;
-    },
-  }),
+  baseQuery: baseQueryReauth,
   endpoints: (builder) => ({
     getUserList: builder.query<{ students: UserTableHead[]; totalPage: number }, number>({
       query: (page) => `admin/students?page=${page}`,


### PR DESCRIPTION
토큰 만료 시 로그아웃이 되는 등의 조치가 없어서 사용자가 어려움을 겪고 개발자도 개발 중에 불편함이 있는 상황입니다.
기존에는 없던 리프레시 토큰으로 액세스 토큰을 갱신하는 api가 추가 되었으므로 클라이언트도 추가했습니다.
요청을 보냈을 때 401 에러라면 액세스 토큰을 갱신한 후 다시 재요청하는 방식으로 처리했습니다.

충돌이 날 수 있어서 이번에 추가한 abtest를 제외한 기존에 사용 중인 모든 api에 적용했습니다.
자동 로그인은 추후 필요하다면 고려 해보겠습니다.
