### PR TITLE
[비즈니스] 메인 카테고리 추가 및 카테고리 정렬 기능 추가

### DIFF
--- a/src/model/category.model.ts
+++ b/src/model/category.model.ts
@@ -17,3 +17,7 @@ export interface CategoriesResponse extends ListPagination {
 export type DropdownCategory = Omit<Category, 'image_url'>;
 
 export type DropdownCategoryResponse = DropdownCategory[];
+
+export interface CategoryOrderRequest {
+  shop_category_ids: number[];
+}

--- a/src/model/store.model.ts
+++ b/src/model/store.model.ts
@@ -40,6 +40,7 @@ export interface StoreResponse {
   pay_card: boolean;
   phone: string;
   shop_categories: ShopCategoriesModel[];
+  main_category_id: number;
 }
 
 export interface StoreDetailForm extends StoreResponse {
@@ -95,6 +96,7 @@ export interface CreateStoreParams {
   pay_bank: boolean;
   pay_card: boolean;
   phone: string;
+  main_category_id: number;
 }
 
 export interface ModifyStoreParams extends CreateStoreParams {

--- a/src/pages/Services/Category/CategoryList.tsx
+++ b/src/pages/Services/Category/CategoryList.tsx
@@ -1,17 +1,75 @@
 import CustomTable from 'components/common/CustomTable';
-import { useGetCategoryListQuery } from 'store/api/category';
+import { useGetCategoryListQuery, useUpdateCategoryOrderMutation } from 'store/api/category';
 import useBooleanState from 'utils/hooks/useBoolean';
 import CustomForm from 'components/common/CustomForm';
+import { Button } from 'antd';
+import { useState } from 'react';
 import * as S from './CategoryList.style';
 import AddCategoryModal from './components/AddCategoryModal';
+
+interface OrderData {
+  id: number;
+  name: string;
+}
+
+function OrderCategory({ orderData }: { orderData: OrderData[] }) {
+  const [items, setItems] = useState(orderData);
+  const [draggedItem, setDraggedItem] = useState<number | null>(null);
+  const [reorder] = useUpdateCategoryOrderMutation();
+
+  const handleDragStart = (index: number) => {
+    setDraggedItem(index);
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLButtonElement>) => {
+    e.preventDefault(); // 드래그 대상이 드롭 가능하도록 설정
+  };
+
+  const handleDrop = (index: number) => {
+    if (draggedItem === null) return;
+
+    // 아이템 순서 변경
+    const updatedItems = [...items];
+    const [removedItem] = updatedItems.splice(draggedItem, 1);
+    updatedItems.splice(index, 0, removedItem);
+
+    setItems(updatedItems);
+    setDraggedItem(null);
+    reorder({
+      shop_category_ids: updatedItems.map((item) => item.id),
+    });
+  };
+
+  return (
+    <>
+      {items.map((item, index) => (
+        <Button
+          draggable
+          key={item.id}
+          onDragOver={handleDragOver}
+          onDragStart={() => handleDragStart(index)}
+          onDrop={() => handleDrop(index)}
+        >
+          {item.name}
+        </Button>
+      ))}
+    </>
+  );
+}
 
 function CategoryList() {
   const { data: categoryData } = useGetCategoryListQuery();
   const { value: isModalOpen, setTrue: openModal, setFalse: closeModal } = useBooleanState();
 
+  const orderData = categoryData?.map((category) => ({
+    id: category.id,
+    name: category.name,
+  }));
+
   return (
     <S.Container>
       <S.Heading>카테고리 목록</S.Heading>
+
       <S.ModalWrap>
         <CustomForm.Modal
           buttonText="생성"
@@ -31,6 +89,7 @@ function CategoryList() {
           columnSize={[10, 20, 20, 20, 30]}
         />
       )}
+      {orderData && <OrderCategory orderData={orderData} />}
 
     </S.Container>
   );

--- a/src/pages/Services/Store/StoreDetail.style.tsx
+++ b/src/pages/Services/Store/StoreDetail.style.tsx
@@ -14,6 +14,12 @@ export const CategoryImg = styled.img`
   border-radius: 50%;
 `;
 
+export const CategoryButtonWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;
+
 export const CategoryItem = styled.div<{ selected: boolean }>`
   display: flex;
   flex-direction: column;

--- a/src/pages/Services/Store/components/StoreCategory.tsx
+++ b/src/pages/Services/Store/components/StoreCategory.tsx
@@ -20,7 +20,8 @@ export default function StoreCategory({ form } : { form: FormInstance }) {
       ? selectedCategory.filter(({ id }) => category.id !== id)
       : [...selectedCategory, category];
 
-    if (!newList.map((item) => item.id).includes(mainCategoryId)) return;
+    if (categories.map((item) => item.id).includes(mainCategoryId)
+      && !newList.map((item) => item.id).includes(mainCategoryId)) return;
 
     form.setFieldsValue({
       shop_categories: newList,

--- a/src/pages/Services/Store/components/StoreCategory.tsx
+++ b/src/pages/Services/Store/components/StoreCategory.tsx
@@ -10,6 +10,7 @@ export default function StoreCategory({ form } : { form: FormInstance }) {
   const { data: categoryList } = useGetCategoryListQuery();
   // formData를 직접적으로 수정하면, 렌더링이 발생하지 않아 state를 따로 만들어서 관리
   const [selectedCategory, setSelectedCategory] = useState<ShopCategoriesModel[]>(form.getFieldValue('shop_categories') ?? []);
+  const [mainCategoryId, setMainCategoryId] = useState<number>(form.getFieldValue('main_category_id'));
 
   const changeCategory = (category: Category) => {
     const categories = form.getFieldValue('shop_categories') as ShopCategoriesModel[];
@@ -19,6 +20,8 @@ export default function StoreCategory({ form } : { form: FormInstance }) {
       ? selectedCategory.filter(({ id }) => category.id !== id)
       : [...selectedCategory, category];
 
+    if (!newList.map((item) => item.id).includes(mainCategoryId)) return;
+
     form.setFieldsValue({
       shop_categories: newList,
       category_ids: newList.map(({ id }) => id),
@@ -26,21 +29,35 @@ export default function StoreCategory({ form } : { form: FormInstance }) {
     setSelectedCategory(newList);
   };
 
+  const selectMainCategory = (id: number) => {
+    const selectedIds = selectedCategory.map((item) => item.id);
+    if (selectedIds.includes(id)) {
+      setMainCategoryId(id);
+      form.setFieldValue('main_category_id', id);
+    }
+  };
+
   return (
     <div>
       <Divider orientation="left">카테고리</Divider>
-
       {categoryList && (
         <S.CategoryWrap>
           {categoryList.map((category) => (
-            <S.CategoryItem
-              selected={selectedCategory?.some(({ id }) => id === category.id)}
-              key={category.id}
-              onClick={() => changeCategory(category)}
-            >
-              <S.CategoryImg src={category.image_url} />
-              <span>{category.name}</span>
-            </S.CategoryItem>
+            <S.CategoryButtonWrap>
+              <S.CategoryItem
+                selected={selectedCategory?.some(({ id }) => id === category.id)}
+                key={category.id}
+                onClick={() => changeCategory(category)}
+              >
+                <S.CategoryImg src={category.image_url} />
+                <span>{category.name}</span>
+              </S.CategoryItem>
+              <input
+                type="checkbox"
+                checked={mainCategoryId === category.id}
+                onChange={() => selectMainCategory(category.id)}
+              />
+            </S.CategoryButtonWrap>
           ))}
         </S.CategoryWrap>
       )}

--- a/src/pages/Services/Store/components/StoreDetailForm.tsx
+++ b/src/pages/Services/Store/components/StoreDetailForm.tsx
@@ -27,6 +27,7 @@ export default function StoreDetailForm({ form }: { form: FormInstance }) {
       <CustomForm.Input label="주소" name="address" rules={[max(65535), required]} />
       <CustomForm.TextArea label="설명" name="description" maxLength={200} rules={[required]} />
       <CustomForm.Input label="카테고리 목록" name="category_ids" disabled rules={[required]} />
+      <CustomForm.Input label="메인 카테고리" name="main_category_id" disabled rules={[required]} />
       <StoreCategory form={form} />
       <OpenTimeForm form={form} />
       <Divider orientation="left" style={{ marginTop: '40px' }}>

--- a/src/store/api/category/index.ts
+++ b/src/store/api/category/index.ts
@@ -1,5 +1,7 @@
 import { createApi } from '@reduxjs/toolkit/query/react';
-import { CategoriesResponseV2, Category, DropdownCategoryResponse } from 'model/category.model';
+import {
+  CategoriesResponseV2, Category, CategoryOrderRequest, DropdownCategoryResponse,
+} from 'model/category.model';
 import baseQueryReauth from 'store/api/baseQueryReauth';
 
 export const categoryApi = createApi({
@@ -51,10 +53,20 @@ export const categoryApi = createApi({
       query: () => ({ url: 'admin/shops/parent-categories' }),
       providesTags: () => [{ type: 'category', name: 'parent' }],
     }),
+
+    updateCategoryOrder: builder.mutation<string, CategoryOrderRequest>({
+      query: (body) => ({
+        url: 'admin/shops/categories/order',
+        method: 'PUT',
+        body,
+      }),
+      invalidatesTags: () => [{ type: 'category' }],
+    }),
   }),
 });
 
 export const {
   useGetCategoryListQuery, useGetCategoryQuery, useAddCategoryMutation,
   useUpdateCategoryMutation, useDeleteCategoryMutation, useGetParentCategoryQuery,
+  useUpdateCategoryOrderMutation,
 } = categoryApi;


### PR DESCRIPTION
상점 추가 및 수정 시 메인 카테고리를 지정하는 기능을 추가했습니다.
또한 드래그 앤 드롭 기능을 이용해서 카테고리를 정렬하는 기능을 추가했습니다.
테이블을 직접 드래그 앤 드롭 가능하게 만들고 싶었지만 기존 테이블의 틀을 많이 벗어나는 작업이므로 시간 관계상 임의로 작업했습니다.

![image](https://github.com/user-attachments/assets/6625502f-5227-48ca-91f0-6b7f5fcce390)
