### PR TITLE
[동아리] 동아리 어드민 QA 수정

### DIFF
--- a/src/constant/index.ts
+++ b/src/constant/index.ts
@@ -33,6 +33,7 @@ export const TITLE_MAPPER: Record<string, string> = {
   created_at: '생성일',
   club_category_name: '분과 카테고리',
   club_managers: '동아리 관리자',
+  club_manager_id: '동아리 관리자 ID',
   club_manager_name: '이름',
   club_name: '동아리명',
 };

--- a/src/model/clubRequest.model.ts
+++ b/src/model/clubRequest.model.ts
@@ -1,7 +1,9 @@
 import { ListPagination } from './common.model';
 
 export interface PendingClubTableHead {
+  index: number;
   club_id: number;
+  club_manager_id: number;
   club_manager_name: string;
   phone_number: string;
   created_at: string;

--- a/src/pages/Services/Banner/BannerWrite.tsx
+++ b/src/pages/Services/Banner/BannerWrite.tsx
@@ -27,6 +27,7 @@ export default function BannerWrite() {
     value: isAddModalOpen,
     setFalse: closeAddModal,
   } = useBooleanState();
+
   const {
     setTrue: openDeleteModal,
     value: isDeleteModalOpen,

--- a/src/pages/Services/Club/ClubDetail.tsx
+++ b/src/pages/Services/Club/ClubDetail.tsx
@@ -141,7 +141,7 @@ function ClubDetailContent() {
           initialValues={initialValues || {}}
           onValuesChange={handleValuesChange}
         >
-          <ClubForm form={form} categoryOptions={clubCategoryOptions} />
+          <ClubForm form={form} categoryOptions={clubCategoryOptions} isEdit />
         </CustomForm>
         <Flex justify="end" gap="10px">
           <CustomForm.Modal

--- a/src/pages/Services/Club/ClubList.tsx
+++ b/src/pages/Services/Club/ClubList.tsx
@@ -56,7 +56,7 @@ export default function ClubList() {
             onChange: setPage,
             total: clubRes.total_page,
           }}
-          columnSize={[5, 10, 10, 15, 10, 10, 10]}
+          columnSize={[5, 15, 10, 15, 10, 10, 10]}
           columns={columns}
         />
       )}

--- a/src/pages/Services/Club/ClubWrite.tsx
+++ b/src/pages/Services/Club/ClubWrite.tsx
@@ -1,4 +1,5 @@
 import { Flex } from 'antd';
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ClubFormValues, ClubRequest } from 'model/club.model';
 import { useGetClubCategoryListQuery } from 'store/api/club';
@@ -65,6 +66,12 @@ export default function ClubWrite() {
     }
   };
 
+  useEffect(() => {
+    form.setFieldsValue({
+      is_active: true,
+    });
+  }, [form]);
+
   return (
     <S.Container>
       <DetailHeading>동아리 추가</DetailHeading>
@@ -74,7 +81,7 @@ export default function ClubWrite() {
           onFinish={handleFinish}
           onValuesChange={handleValuesChange}
         >
-          <ClubForm form={form} categoryOptions={clubCategoryOptions} />
+          <ClubForm form={form} categoryOptions={clubCategoryOptions} isEdit={false} />
         </CustomForm>
         <Flex justify="end" gap="10px">
           <CustomForm.Modal

--- a/src/pages/Services/Club/ClubWrite.tsx
+++ b/src/pages/Services/Club/ClubWrite.tsx
@@ -1,4 +1,5 @@
 import { Flex } from 'antd';
+import { useNavigate } from 'react-router-dom';
 import { ClubFormValues, ClubRequest } from 'model/club.model';
 import { useGetClubCategoryListQuery } from 'store/api/club';
 import CustomForm from 'components/common/CustomForm';
@@ -11,6 +12,7 @@ import ClubForm from './Components/ClubForm/ClubForm';
 
 export default function ClubWrite() {
   const [form] = CustomForm.useForm();
+  const navigate = useNavigate();
 
   const { data: ClubCategory } = useGetClubCategoryListQuery();
   const { addClub } = useClubMutation();
@@ -41,6 +43,7 @@ export default function ClubWrite() {
 
   const handleCancel = () => {
     closeCancelModal();
+    navigate(-1);
   };
 
   const handleFinish = (values: ClubFormValues) => {

--- a/src/pages/Services/Club/Components/ClubForm/ClubForm.tsx
+++ b/src/pages/Services/Club/Components/ClubForm/ClubForm.tsx
@@ -38,7 +38,7 @@ export default function ClubForm({ form, categoryOptions }: ClubFormProps) {
         <CustomForm.Input label="좋아요" name="likes" disabled />
         <CustomForm.Input label="등록일자" name="created_at" disabled />
       </CustomForm.GridRow>
-      <CustomForm.Input label="동아리 소개" name="description" rules={[required()]} />
+      <CustomForm.Input label="동아리 소개" name="description" />
 
       <Divider orientation="left">연락처</Divider>
       <CustomForm.Input label="전화" name="phone_number" />

--- a/src/pages/Services/Club/Components/ClubForm/ClubForm.tsx
+++ b/src/pages/Services/Club/Components/ClubForm/ClubForm.tsx
@@ -3,10 +3,11 @@ import CustomForm from 'components/common/CustomForm';
 
 interface ClubFormProps {
   form: FormInstance;
+  isEdit: boolean;
   categoryOptions: Record<string, string>;
 }
 
-export default function ClubForm({ form, categoryOptions }: ClubFormProps) {
+export default function ClubForm({ form, categoryOptions, isEdit }: ClubFormProps) {
   const { required } = CustomForm.validateUtils();
 
   return (
@@ -50,7 +51,7 @@ export default function ClubForm({ form, categoryOptions }: ClubFormProps) {
       <CustomForm.SingleUpload form={form} name="image_url" domain="club" accept="image/*" />
 
       <Divider orientation="left" style={{ marginTop: '40px' }} />
-      <CustomForm.Switch label="활성화 여부" name="is_active" />
+      <CustomForm.Switch label="활성화 여부" name="is_active" disabled={!isEdit} />
     </>
   );
 }

--- a/src/pages/UserManage/ClubManager/ClubManagerList.tsx
+++ b/src/pages/UserManage/ClubManager/ClubManagerList.tsx
@@ -9,10 +9,10 @@ export default function ClubManagerList() {
 
   const transformedRes = clubManagerRes && {
     ...clubManagerRes,
-    clubs: clubManagerRes.clubs.map((club, index) => {
-      const { club_id: clubId, ...rest } = club;
+    clubs: clubManagerRes.clubs.map((club) => {
+      const { index, club_id: clubId, ...rest } = club;
       return {
-        id: index + 1,
+        id: index,
         ...rest,
       };
     }),
@@ -29,7 +29,7 @@ export default function ClubManagerList() {
           onChange: setPage,
           total: transformedRes.total_page,
         }}
-        columnSize={[10, 25, 15, 25, 25]}
+        columnSize={[5, 15, 15, 15, 15, 25]}
         onClick={() => { }}
       />
       )}

--- a/src/pages/UserManage/ClubManagerRequest/ClubManagerRequestList.style.tsx
+++ b/src/pages/UserManage/ClubManagerRequest/ClubManagerRequestList.style.tsx
@@ -1,1 +1,7 @@
+import { styled } from 'styled-components';
+
 export * from 'styles/List.style';
+
+export const TableContainer = styled.div`
+  width : 1100px;
+  `;

--- a/src/pages/UserManage/ClubManagerRequest/ClubManagerRequestList.tsx
+++ b/src/pages/UserManage/ClubManagerRequest/ClubManagerRequestList.tsx
@@ -4,6 +4,8 @@ import { useGetPendingClubListQuery } from 'store/api/clubRequest';
 import customColumns from './Components/CustomColumns/CustomColumns';
 import * as S from './ClubManagerRequestList.style';
 
+const pageSize = 10;
+
 export default function ClubManagerList() {
   const [page, setPage] = useState(1);
   const { data: clubManagerRes } = useGetPendingClubListQuery({ page });
@@ -13,7 +15,7 @@ export default function ClubManagerList() {
     clubs: clubManagerRes.clubs.map((club, index) => {
       const { club_id: clubId, ...rest } = club;
       return {
-        id: index + 1,
+        id: (page - 1) * pageSize + index + 1,
         ...rest,
         is_accept: true,
         info: true,

--- a/src/pages/UserManage/ClubManagerRequest/ClubManagerRequestList.tsx
+++ b/src/pages/UserManage/ClubManagerRequest/ClubManagerRequestList.tsx
@@ -1,6 +1,6 @@
-import CustomTable from 'components/common/CustomTable';
 import { useState } from 'react';
 import { useGetPendingClubListQuery } from 'store/api/clubRequest';
+import CustomTable from 'components/common/CustomTable';
 import customColumns from './Components/CustomColumns/CustomColumns';
 import * as S from './ClubManagerRequestList.style';
 
@@ -14,8 +14,9 @@ export default function ClubManagerList() {
     ...clubManagerRes,
     clubs: clubManagerRes.clubs.map((club, index) => {
       const { club_id: clubId, ...rest } = club;
+
       return {
-        id: (page - 1) * pageSize + index + 1,
+        id: clubManagerRes.total_count - ((page - 1) * pageSize + index),
         ...rest,
         is_accept: true,
         info: true,

--- a/src/pages/UserManage/ClubManagerRequest/ClubManagerRequestList.tsx
+++ b/src/pages/UserManage/ClubManagerRequest/ClubManagerRequestList.tsx
@@ -4,19 +4,16 @@ import CustomTable from 'components/common/CustomTable';
 import customColumns from './Components/CustomColumns/CustomColumns';
 import * as S from './ClubManagerRequestList.style';
 
-const pageSize = 10;
-
 export default function ClubManagerList() {
   const [page, setPage] = useState(1);
   const { data: clubManagerRes } = useGetPendingClubListQuery({ page });
 
   const transformedRes = clubManagerRes && {
     ...clubManagerRes,
-    clubs: clubManagerRes.clubs.map((club, index) => {
-      const { club_id: clubId, ...rest } = club;
-
+    clubs: clubManagerRes.clubs.map((club) => {
+      const { index, club_id: clubId, ...rest } = club;
       return {
-        id: clubManagerRes.total_count - ((page - 1) * pageSize + index),
+        id: index,
         ...rest,
         is_accept: true,
         info: true,
@@ -25,7 +22,7 @@ export default function ClubManagerList() {
   };
 
   return (
-    <S.Container>
+    <S.TableContainer>
       <S.Heading>동아리 관리자</S.Heading>
       {transformedRes && (
       <CustomTable
@@ -35,11 +32,11 @@ export default function ClubManagerList() {
           onChange: setPage,
           total: transformedRes.total_page,
         }}
-        columnSize={[10, 10, 15, 15, 15, 15, 20]}
+        columnSize={[5, 15, 10, 15, 10, 20, 15, 15]}
         onClick={() => { }}
         columns={customColumns()}
       />
       )}
-    </S.Container>
+    </S.TableContainer>
   );
 }

--- a/src/pages/UserManage/ClubManagerRequest/Components/CustomColumns/RequestInfo/RequestInfo.style.tsx
+++ b/src/pages/UserManage/ClubManagerRequest/Components/CustomColumns/RequestInfo/RequestInfo.style.tsx
@@ -15,6 +15,7 @@ export const Content = styled.div`
   `;
 
 export const ClubImage = styled.img`
+  margin-top: 30px;
   height: auto;
   max-width: 400px;
 `;

--- a/src/pages/UserManage/ClubManagerRequest/Components/CustomColumns/RequestInfo/RequestInfo.tsx
+++ b/src/pages/UserManage/ClubManagerRequest/Components/CustomColumns/RequestInfo/RequestInfo.tsx
@@ -1,4 +1,4 @@
-import { Col, Divider, Flex } from 'antd';
+import { Col, Divider } from 'antd';
 import { useGetPendingClubQuery } from 'store/api/clubRequest';
 import { Suspense } from 'react';
 import * as S from './RequestInfo.style';
@@ -20,16 +20,14 @@ function RequestInfoContent({ name }: RequestInfoProps) {
 
   return (
     <>
-      <Flex gap={20}>
-        <S.Title>
-          동아리명 :
-          {' '}
-          {pendingClubRes.name}
-        </S.Title>
-        <S.Content>
-          <S.ClubImage src={pendingClubRes.image_url} alt="club" />
-        </S.Content>
-      </Flex>
+      <S.Title>
+        동아리명 :
+        {' '}
+        {pendingClubRes.name}
+      </S.Title>
+      <S.Content>
+        <S.ClubImage src={pendingClubRes.image_url} alt="club" />
+      </S.Content>
 
       <Divider orientation="left">
         <S.SectionTitle>

--- a/src/pages/UserManage/ClubManagerRequest/Components/CustomColumns/RequestInfo/RequestInfo.tsx
+++ b/src/pages/UserManage/ClubManagerRequest/Components/CustomColumns/RequestInfo/RequestInfo.tsx
@@ -12,7 +12,8 @@ function LoadingFallback() {
 }
 
 function RequestInfoContent({ name }: RequestInfoProps) {
-  const { data: pendingClubRes } = useGetPendingClubQuery(name);
+  const encodedName = encodeURIComponent(name);
+  const { data: pendingClubRes } = useGetPendingClubQuery(encodedName);
 
   if (!pendingClubRes) {
     return null;


### PR DESCRIPTION
close #88 

### 수정 내용
- 동아리 생성 페이지에서 활성화 토글 스위치 활성 상태 고정 누락
- 동아리 수정 페이지에서 소개에 공란이 들어가도 경고 문구가 사라지는 이슈
- 동아리 관리자 id가 1~ 10으로 고정됨 
- 동아리 추가 페이지에서 등록 취소하기 → 모달에서 ‘등록 취소’를 누르면 원래 아무 액션이 없음
- 승인 대기 상태의 동아리 정보 슬라이드에서 사진 크기에 따른 폰트 잘림 현상


### 그 외 이슈
- 이미지 업로드 란에 이미지가 아닌 다른 파일이 올라가는 이슈는 리눅스 환경 파일탐색기의 로직이 다름으로 인해 발생하는 것으로 확인되어 추후 리눅스 환경에서 테스트 및 수정하도록 논의했습니다.
- 동아리명에 특수문자 입력 시 API 호출 오류 발생하는 문제는 백엔드에서 동아리명에 특수문자, 이모지 검증을 통해 방지하도록 진행되었습니다.
