### PR TITLE
[상점] 상점 생성, 수정 시 주소 검증 추가 및 상세 주소 필드 분리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import RoomList from 'pages/Services/Room/RoomList';
 import RoomDetail from 'pages/Services/Room/RoomDetail';
 import MemberDetail from 'pages/UserManage/Member/MemberDetail';
 import { useToken } from 'store/slice/auth';
+import StoreWrite from 'pages/Services/Store/StoreWrite';
 import StoreDetail from 'pages/Services/Store/StoreDetail';
 import CategoryDetail from 'pages/Services/Category/CategoryDetail';
 import OwnerList from 'pages/UserManage/Owner/OwnerList';
@@ -60,6 +61,7 @@ function App() {
       <Route path="/" element={<RequireAuth />}>
         <Route index element={<Store />} />
         <Route path="/store" element={<Store />} />
+        <Route path="/store/write" element={<StoreWrite />} />
         <Route path="/store/:id" element={<StoreDetail />} />
         <Route path="/category" element={<CategoryList />} />
         <Route path="/category/:id" element={<CategoryDetail />} />

--- a/src/components/common/CustomForm/index.tsx
+++ b/src/components/common/CustomForm/index.tsx
@@ -171,7 +171,8 @@ interface CustomModalProps {
 }
 
 function CustomModal({
-  buttonText, title, width, footer, children, open, onCancel, onClick, hasIcon = true, isDelete,
+  buttonText,
+  title, width, footer, children, open, onCancel, onClick, hasIcon = true, isDelete, destroyOnClose,
 }: CustomModalProps & ModalProps) {
   return (
     <>
@@ -189,6 +190,7 @@ function CustomModal({
         centered
         width={width}
         footer={footer}
+        destroyOnClose={destroyOnClose}
       >
         {children}
       </Modal>

--- a/src/model/address.model.ts
+++ b/src/model/address.model.ts
@@ -1,0 +1,25 @@
+export interface Address {
+  bd_nm: string;
+  emd_nm: string;
+  eng_address: string;
+  jibun_address: string;
+  li_nm: string;
+  rn: string;
+  road_address: string;
+  sgg_nm: string;
+  si_nm: string;
+  zip_no: string;
+}
+
+export interface AddressSearchRequest {
+  keyword: string;
+  currentPage?: string;
+  countPerPage?: string;
+}
+
+export interface AddressSearchResponse {
+  count_per_page: number;
+  current_page: number;
+  total_count: string;
+  addresses: Address[]
+}

--- a/src/model/store.model.ts
+++ b/src/model/store.model.ts
@@ -86,6 +86,7 @@ export interface StoreParams {
 
 export interface CreateStoreParams {
   address: string;
+  address_detail: string
   category_ids: number[];
   delivery: true;
   delivery_price: number;

--- a/src/pages/Services/Store/StoreList.tsx
+++ b/src/pages/Services/Store/StoreList.tsx
@@ -1,15 +1,15 @@
-import CustomTable from 'components/common/CustomTable';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button, Flex, Switch } from 'antd';
+import { PlusOutlined } from '@ant-design/icons';
+import CustomTable from 'components/common/CustomTable';
 import { useGetStoreListQuery } from 'store/api/store';
-import CustomForm from 'components/common/CustomForm';
 import useBooleanState from 'utils/hooks/useBoolean';
-import { Switch } from 'antd';
 import * as S from './StoreList.style';
-import AddStoreModal from './components/AddStoreModal';
 
 function StoreList() {
+  const navigate = useNavigate();
   const [page, setPage] = useState(1);
-  const { setTrue: openModal, value: isModalOpen, setFalse: closeModal } = useBooleanState();
   const { value: isDeletedStore, changeValue: containIsDeletedStore } = useBooleanState(false);
   const { data: StoreRes } = useGetStoreListQuery({
     page,
@@ -20,17 +20,14 @@ function StoreList() {
     <S.Container>
       <S.Heading>주변 상점 목록</S.Heading>
       <S.ModalWrap>
-        <CustomForm.Modal
-          buttonText="생성"
-          title="등록하기"
-          width={900}
-          footer={null}
-          open={isModalOpen}
-          onCancel={closeModal}
-          onClick={openModal}
-        >
-          <AddStoreModal closeModal={closeModal} />
-        </CustomForm.Modal>
+        <Flex justify="end">
+          <Button
+            icon={<PlusOutlined />}
+            onClick={() => navigate('/store/write')}
+          >
+            생성
+          </Button>
+        </Flex>
       </S.ModalWrap>
       <S.SwitchWrapper>
         <Switch

--- a/src/pages/Services/Store/StoreWrite.style.tsx
+++ b/src/pages/Services/Store/StoreWrite.style.tsx
@@ -1,0 +1,13 @@
+import { styled } from 'styled-components';
+
+export * from 'styles/List.style';
+
+export const HeadingWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  margin: 8px 0 16px;
+  .ant-btn-icon-only {
+    border: none;
+    margin-right: 5px;
+  }
+`;

--- a/src/pages/Services/Store/StoreWrite.tsx
+++ b/src/pages/Services/Store/StoreWrite.tsx
@@ -1,0 +1,100 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Flex, message } from 'antd';
+import { UploadOutlined } from '@ant-design/icons';
+import STORE_OPTION from 'constant/store';
+import { CreateStoreParams, DAY } from 'model/store.model';
+import CustomForm from 'components/common/CustomForm';
+import DetailHeading from 'components/common/DetailHeading';
+import * as S from 'styles/Detail.style';
+import * as L from './StoreWrite.style';
+import useStoreMutation from './components/useStoreMutation';
+import StoreDetailForm from './components/StoreDetailForm';
+
+const DAYS = ['월', '화', '수', '목', '금', '토', '일'];
+
+export default function StoreWrite() {
+  const navigate = useNavigate();
+  const [form] = CustomForm.useForm<CreateStoreParams>();
+  const { addStore } = useStoreMutation(1);
+
+  const defaultTimeInfo = DAYS.map((day, index) => {
+    return (
+      {
+        close_time: '00:00',
+        closed: false,
+        day_of_week: DAY[index],
+        open_time: '00:00',
+      });
+  });
+
+  const buildFinalAddress = () => {
+    const base = (form.getFieldValue('address') ?? '').toString().trim();
+    const detail = (form.getFieldValue('address_detail') ?? '').toString().trim();
+    return [base, detail].filter(Boolean).join(' ');
+  };
+
+  const createStore = (values: Partial<CreateStoreParams>) => {
+    const openField = form.getFieldValue('open');
+    const finalAddress = buildFinalAddress();
+
+    const payload = {
+      ...values,
+      address: finalAddress,
+      open: openField,
+    } as Partial<CreateStoreParams>;
+
+    addStore(
+      payload,
+      {
+        onSuccess: () => {
+          message.success('정보 추가가 완료되었습니다.');
+          form.resetFields();
+          navigate(-1);
+        },
+        onError: (errorMessage) => {
+          message.error(errorMessage);
+        },
+      },
+    );
+  };
+
+  useEffect(() => {
+    STORE_OPTION.forEach((optionData) => {
+      form.setFieldValue(optionData.data, false);
+    });
+    form.setFieldValue('image_urls', []);
+  }, [form]);
+
+  return (
+    <S.Container>
+      <L.HeadingWrapper>
+        <DetailHeading>Store Create</DetailHeading>
+      </L.HeadingWrapper>
+      <CustomForm
+        onFinish={createStore}
+        form={form}
+        initialValues={{
+          open: defaultTimeInfo,
+        }}
+      >
+        <L.DetailFormWrap>
+          <StoreDetailForm form={form} />
+
+          <Flex justify="end" gap="10px">
+            <CustomForm.Button icon={<UploadOutlined />} htmlType="submit">
+              완료
+            </CustomForm.Button>
+
+            <CustomForm.Button
+              type="default"
+              onClick={() => navigate(-1)}
+            >
+              취소
+            </CustomForm.Button>
+          </Flex>
+        </L.DetailFormWrap>
+      </CustomForm>
+    </S.Container>
+  );
+}

--- a/src/pages/Services/Store/components/AddressSearch.style.tsx
+++ b/src/pages/Services/Store/components/AddressSearch.style.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+export const BuildingName = styled.div`
+  font-size: 16px;
+  font-weight: 700;
+`;
+
+export const RoadAddress = styled.div`
+  font-size: 14px;
+  color: #797979ff
+`;

--- a/src/pages/Services/Store/components/AddressSearch.tsx
+++ b/src/pages/Services/Store/components/AddressSearch.tsx
@@ -1,0 +1,69 @@
+import {
+  Form, Input, Button, List, Space,
+} from 'antd';
+import { Address } from 'model/address.model';
+import { useLazyGetAddressSearchQuery } from 'store/api/address';
+import * as S from './AddressSearch.style';
+
+const { Search } = Input;
+
+interface AddressSearchProps {
+  onSelect: (address: Address) => void;
+}
+
+export default function AddressSearch({ onSelect } : AddressSearchProps) {
+  const [form] = Form.useForm<{ keyword: string }>();
+  const [trigger, { data, isFetching }] = useLazyGetAddressSearchQuery();
+
+  const items = data?.addresses ?? [];
+
+  const onFinish = ({ keyword }: { keyword: string }) => {
+    trigger({ keyword });
+  };
+
+  const watched = Form.useWatch('keyword', form) ?? '';
+  const isDisabled = !watched.trim();
+
+  return (
+    <S.Container>
+      <Form
+        form={form}
+        onFinish={onFinish}
+      >
+        <Form.Item
+          name="keyword"
+          rules={[{ required: true, message: '검색어를 입력하세요' }]}
+          style={{ margin: 0 }}
+        >
+          <Search
+            placeholder="도로명/지번/건물명으로 검색"
+            allowClear
+            enterButton={(
+              <Button type="primary" loading={isFetching} disabled={isDisabled}>
+                검색
+              </Button>
+      )}
+            onSearch={() => form.submit()}
+            size="large"
+          />
+        </Form.Item>
+      </Form>
+
+      <div>
+        <List
+          bordered
+          loading={isFetching}
+          dataSource={items}
+          renderItem={(address) => (
+            <List.Item key={`${address.road_address}-${address.zip_no}-${address.eng_address}`} onClick={() => onSelect(address)}>
+              <Space direction="vertical" size={0}>
+                <S.BuildingName>{address.bd_nm === '' ? address.road_address : address.bd_nm}</S.BuildingName>
+                <S.RoadAddress>{address.road_address}</S.RoadAddress>
+              </Space>
+            </List.Item>
+          )}
+        />
+      </div>
+    </S.Container>
+  );
+}

--- a/src/pages/Services/Store/components/StoreDetailForm.tsx
+++ b/src/pages/Services/Store/components/StoreDetailForm.tsx
@@ -3,12 +3,25 @@ import CustomForm from 'components/common/CustomForm';
 import { Divider } from 'antd';
 import { FormInstance } from 'antd/es/form/Form';
 import STORE_OPTION from 'constant/store';
-import * as S from '../StoreDetail.style';
+import useBooleanState from 'utils/hooks/useBoolean';
+import { Address } from 'model/address.model';
 import StoreCategory from './StoreCategory';
 import OpenTimeForm from './OpenTimeForm';
+import AddressSearch from './AddressSearch';
+import * as S from '../StoreDetail.style';
 
 export default function StoreDetailForm({ form }: { form: FormInstance }) {
   const { required, max, pattern } = CustomForm.validateUtils();
+  const { value: isModalOpen, setTrue: openModal, setFalse: closeModal } = useBooleanState(false);
+
+  const handleSelect = (address: Address) => {
+    form.setFieldsValue({
+      address: address.road_address,
+      address_detail: '',
+    });
+
+    closeModal();
+  };
 
   return (
     <>
@@ -24,7 +37,24 @@ export default function StoreDetailForm({ form }: { form: FormInstance }) {
         />
         <CustomForm.InputNumber label="배달비" name="delivery_price" rules={[required]} />
       </CustomForm.GridRow>
-      <CustomForm.Input label="주소" name="address" rules={[max(65535), required]} />
+      <CustomForm.GridRow gridColumns="1fr 0.1fr">
+        <CustomForm.Input label="주소" name="address" disabled rules={[max(65535), required]} />
+        <CustomForm.Modal
+          buttonText="주소 검색"
+          title="검색"
+          width={900}
+          footer={null}
+          open={isModalOpen}
+          onCancel={closeModal}
+          onClick={openModal}
+          destroyOnClose
+        >
+          <AddressSearch
+            onSelect={handleSelect}
+          />
+        </CustomForm.Modal>
+      </CustomForm.GridRow>
+      <CustomForm.Input label="상세주소" name="address_detail" rules={[max(65535)]} />
       <CustomForm.TextArea label="설명" name="description" maxLength={200} rules={[required]} />
       <CustomForm.Input label="카테고리 목록" name="category_ids" disabled rules={[required]} />
       <CustomForm.Input label="메인 카테고리" name="main_category_id" disabled rules={[required]} />

--- a/src/store/api/address/index.ts
+++ b/src/store/api/address/index.ts
@@ -1,0 +1,23 @@
+import { createApi } from '@reduxjs/toolkit/query/react';
+import { AddressSearchRequest, AddressSearchResponse } from 'model/address.model';
+import baseQueryReauth from 'store/api/baseQueryReauth';
+
+export const addressApi = createApi({
+  reducerPath: 'address',
+  baseQuery: baseQueryReauth,
+  tagTypes: ['address'],
+
+  endpoints: (builder) => ({
+    getAddressSearch: builder.query<AddressSearchResponse, AddressSearchRequest>({
+      query: ({ keyword, currentPage = '1', countPerPage = '10' }) => ({
+        url: 'address/search',
+        params: { keyword, currentPage, countPerPage },
+      }),
+    }),
+  }),
+});
+
+export const {
+  useGetAddressSearchQuery,
+  useLazyGetAddressSearchQuery,
+} = addressApi;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -22,6 +22,7 @@ import { bannerApi } from './api/banner';
 import { bannerCategoryApi } from './api/bannerCategory';
 import { clubApi } from './api/club';
 import { clubRequestApi } from './api/clubRequest';
+import { addressApi } from './api/address';
 
 const apiList = [
   authApi,
@@ -46,6 +47,7 @@ const apiList = [
   bannerCategoryApi,
   clubApi,
   clubRequestApi,
+  addressApi,
 ];
 
 const apiMiddleware = apiList.map((api) => api.middleware);


### PR DESCRIPTION
close #91 

상점 생성 및 정보 수정 시 주소 검증을 추가했습니다
기존 상점 생성 모달 방식을 유지할 경우 주소 검색 모달로 인해 nested modal 구조가 되어 생성 페이지로 변경하였습니다.

<img width="1274" height="970" alt="image" src="https://github.com/user-attachments/assets/cda43aec-9d61-4ed0-b513-83e0577eebab" />
