### PR TITLE
[콜밴] 신고된 사용자 목록 조회 및 처리 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import History from 'pages/History';
 import BannerList from 'pages/Services/Banner/BannerList';
 import BannerWrite from 'pages/Services/Banner/BannerWrite';
 import BannerDetail from 'pages/Services/Banner/BannerDetail';
+import CallvanList from 'pages/Services/Callvan/CallvanList';
 import ClubList from 'pages/Services/Club/ClubList';
 import ClubDetail from 'pages/Services/Club/ClubDetail';
 import ClubWrite from 'pages/Services/Club/ClubWrite';
@@ -99,6 +100,7 @@ function App() {
         <Route path="/club/write" element={<ClubWrite />} />
         <Route path="/club-manager" element={<ClubManagerList />} />
         <Route path="/club-manager-request" element={<ClubManagerRequestList />} />
+        <Route path="/callvan" element={<CallvanList />} />
         <Route path="*" element={<h1>404</h1>} />
       </Route>
     </Routes>

--- a/src/api/callvan.ts
+++ b/src/api/callvan.ts
@@ -1,0 +1,15 @@
+import accessClient from 'api';
+import type { CallvanParam, CallvanListResponse } from 'model/callvan.model';
+
+export const getCallvanList = async ({ only_pending, page, limit }: CallvanParam) => {
+  const response = await accessClient.get<CallvanListResponse>('admin/callvan/reports', {
+    params: {
+      only_pending,
+      page,
+      limit,
+    },
+  });
+  return response.data;
+};
+
+export default getCallvanList;

--- a/src/api/callvan.ts
+++ b/src/api/callvan.ts
@@ -1,5 +1,5 @@
 import accessClient from 'api';
-import type { CallvanParam, CallvanListResponse } from 'model/callvan.model';
+import type { CallvanParam, CallvanListResponse, CallvanBanRequest } from 'model/callvan.model';
 
 export const getCallvanList = async ({ only_pending, page, limit }: CallvanParam) => {
   const response = await accessClient.get<CallvanListResponse>('admin/callvan/reports', {
@@ -12,4 +12,7 @@ export const getCallvanList = async ({ only_pending, page, limit }: CallvanParam
   return response.data;
 };
 
-export default getCallvanList;
+export const postCallvanReports = async ({ reportId, process_type }: CallvanBanRequest) => {
+  const response = await accessClient.post(`admin/callvan/reports/${reportId}/process`, { process_type });
+  return response;
+};

--- a/src/components/common/SideNav/index.tsx
+++ b/src/components/common/SideNav/index.tsx
@@ -5,7 +5,7 @@ import {
   UserAddOutlined, BoldOutlined, ApartmentOutlined, SnippetsOutlined, GiftOutlined,
   NotificationOutlined, IssuesCloseOutlined, FormOutlined, UnorderedListOutlined,
   HistoryOutlined, FlagOutlined, BellOutlined, CommentOutlined, UsergroupAddOutlined,
-  ScheduleOutlined, SolutionOutlined,
+  ScheduleOutlined, SolutionOutlined, CarOutlined,
 } from '@ant-design/icons';
 import {
   Button, Flex, Menu, MenuProps,
@@ -46,6 +46,7 @@ const items: MenuProps['items'] = [
     getItem('공지사항', '/notice', <NotificationOutlined />),
     getItem('배너 관리', '/banner', <BellOutlined />),
     getItem('동아리 관리', '/club', <CommentOutlined />),
+    getItem('콜밴팟 사용자 관리', '/callvan', <CarOutlined />),
   ]),
 
   getItem('회원 관리', 'user', <UserOutlined />, [

--- a/src/model/callvan.model.ts
+++ b/src/model/callvan.model.ts
@@ -1,0 +1,68 @@
+export interface CallvanParam {
+  page: number;
+  limit: number;
+  only_pending: boolean;
+}
+
+export interface CallvanReportReason {
+  reason_code: string;
+  custom_text: string;
+}
+
+export interface CallvanAccumulatedReport {
+  report_id: number;
+  reported_at: string;
+  report_status: string;
+  process_type: string;
+  restricted_until: string;
+  reasons: CallvanReportReason[];
+}
+
+export interface CallvanReport {
+  report_id: number;
+  report_status: string;
+  reported_user: {
+    id: number;
+    name: string;
+    nickname: string;
+  };
+  reported_at: string;
+  reasons: CallvanReportReason[];
+  process_type: string;
+  restricted_until: string;
+  description: string;
+  attachment_urls: string[];
+  accumulated_report_count: number;
+  accumulated_reports: CallvanAccumulatedReport[];
+}
+
+export interface CallvanListResponse {
+  reports: CallvanReport[];
+  total_count: number;
+  current_count: number;
+  total_page: number;
+  current_page: number;
+}
+
+export interface TransformedCallvanReport {
+  id: number;
+  report_status: string;
+  name: string;
+  nickname: string;
+  reported_at: string;
+  accumulated_report_count: number;
+  accumulated_reports: CallvanAccumulatedReport[];
+  process_type: string;
+  reasons: CallvanReportReason[];
+  description: string;
+  attachment_urls: string[];
+}
+
+export interface TransformedCallvanListResponse {
+  reports: TransformedCallvanReport[];
+  total_page: number;
+}
+
+export interface CallvanBanRequest {
+  reportId: number;
+}

--- a/src/model/callvan.model.ts
+++ b/src/model/callvan.model.ts
@@ -21,11 +21,12 @@ export interface CallvanAccumulatedReport {
 export interface CallvanReport {
   report_id: number;
   report_status: string;
-  reported_user: {
-    id: number;
-    name: string;
-    nickname: string;
-  };
+type CallvanReportedUser = {
+  id: number;
+  name: string;
+  nickname: string;
+};
+  reported_user: CallvanReportedUser
   reported_at: string;
   reasons: CallvanReportReason[];
   process_type: string;

--- a/src/model/callvan.model.ts
+++ b/src/model/callvan.model.ts
@@ -62,6 +62,7 @@ export interface TransformedCallvanReport {
 export interface TransformedCallvanListResponse {
   reports: TransformedCallvanReport[];
   total_page: number;
+  total_count: number;
 }
 
 export interface CallvanBanRequest {

--- a/src/model/callvan.model.ts
+++ b/src/model/callvan.model.ts
@@ -18,15 +18,15 @@ export interface CallvanAccumulatedReport {
   reasons: CallvanReportReason[];
 }
 
-export interface CallvanReport {
-  report_id: number;
-  report_status: string;
-type CallvanReportedUser = {
+export interface CallvanReportUser {
   id: number;
   name: string;
   nickname: string;
-};
-  reported_user: CallvanReportedUser
+}
+export interface CallvanReport {
+  report_id: number;
+  report_status: string;
+  reported_user: CallvanReportUser;
   reported_at: string;
   reasons: CallvanReportReason[];
   process_type: string;
@@ -66,4 +66,5 @@ export interface TransformedCallvanListResponse {
 
 export interface CallvanBanRequest {
   reportId: number;
+  process_type: string;
 }

--- a/src/pages/Services/Callvan/CallvanCard.style.tsx
+++ b/src/pages/Services/Callvan/CallvanCard.style.tsx
@@ -1,0 +1,133 @@
+import styled from 'styled-components';
+import { Select } from 'antd';
+import { CloseOutlined } from '@ant-design/icons';
+
+export const Container = styled.div<{ isPending: boolean }>`
+  display: flex;
+  flex-direction: column;
+  padding: 14px 20px;
+  background: ${(props) => (props.isPending ? '#ffafaf' : '#ffffff')};
+  border: ${(props) => (props.isPending ? 'none' : '2px solid #1890ff')};
+  border-radius: 10px;
+  width: 100%;
+  gap: 10px;
+  margin-top: 20px;
+`;
+
+export const Header = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const HeaderLeft = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;
+
+export const HeaderRight = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;
+
+export const StatusBadge = styled.span<{ isPending: boolean }>`
+  font-weight: 700;
+  font-size: 15px;
+  color: ${(props) => (props.isPending ? '#c0392b' : '#1890ff')};
+`;
+
+export const BadgeCount = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #404040;
+  color: #ffffff;
+  font-size: 12px;
+  font-weight: 700;
+`;
+
+export const InfoRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const InfoGroup = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 24px;
+`;
+
+export const InfoItem = styled.span`
+  font-size: 14px;
+  color: #404040;
+`;
+
+export const Label = styled.span`
+  font-weight: 600;
+`;
+
+export const ProcessText = styled.span`
+  font-size: 14px;
+  color: #404040;
+`;
+
+export const SectionTitle = styled.div`
+  font-weight: 600;
+  font-size: 14px;
+  color: #404040;
+  margin-top: 4px;
+`;
+
+export const SectionContent = styled.div`
+  font-size: 14px;
+  color: #606060;
+  line-height: 1.6;
+`;
+
+export const ImageRow = styled.div`
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+`;
+
+export const AttachImage = styled.img`
+  width: 120px;
+  height: 120px;
+  object-fit: cover;
+  border-radius: 8px;
+`;
+
+export const PopoverHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+`;
+
+export const PopoverClose = styled(CloseOutlined)`
+  cursor: pointer;
+  font-size: 12px;
+  color: #888;
+`;
+
+export const StyledSelect = styled(Select)`
+  .ant-select-selection-placeholder {
+    color: #000000ff;
+  }
+` as typeof Select;
+
+export const ToggleButton = styled.button`
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 4px 0 0;
+`;

--- a/src/pages/Services/Callvan/CallvanCard.style.tsx
+++ b/src/pages/Services/Callvan/CallvanCard.style.tsx
@@ -1,13 +1,13 @@
 import styled from 'styled-components';
-import { Select } from 'antd';
+import { Select, Image } from 'antd';
 import { CloseOutlined } from '@ant-design/icons';
 
 export const Container = styled.div<{ isPending: boolean }>`
   display: flex;
   flex-direction: column;
   padding: 14px 20px;
-  background: ${(props) => (props.isPending ? '#ffafaf' : '#ffffff')};
-  border: ${(props) => (props.isPending ? 'none' : '2px solid #1890ff')};
+  background: ${(props) => (props.isPending ? '#ffafaf' : '#effbff')};
+  border: ${(props) => (props.isPending ? 'none' : '2px solid #effbff')};
   border-radius: 10px;
   width: 100%;
   gap: 10px;
@@ -96,12 +96,12 @@ export const ImageRow = styled.div`
   flex-wrap: wrap;
 `;
 
-export const AttachImage = styled.img`
-  width: 120px;
-  height: 120px;
-  object-fit: cover;
-  border-radius: 8px;
-`;
+export const StyledImage = styled(Image)`
+  .ant-image-img {
+    object-fit: cover;
+    border-radius: 8px;
+  }
+` as typeof Image;
 
 export const PopoverHeader = styled.div`
   display: flex;
@@ -116,7 +116,18 @@ export const PopoverClose = styled(CloseOutlined)`
   color: #888;
 `;
 
+export const EditButton = styled.button`
+  background: transparent;
+  border: 1px solid #1890ff;
+  border-radius: 4px;
+  color: #1890ff;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 2px 8px;
+`;
+
 export const StyledSelect = styled(Select)`
+  width: 180px;
   .ant-select-selection-placeholder {
     color: #000000ff;
   }

--- a/src/pages/Services/Callvan/CallvanCard.tsx
+++ b/src/pages/Services/Callvan/CallvanCard.tsx
@@ -1,0 +1,130 @@
+import { useState } from 'react';
+import { Popover } from 'antd';
+import { CaretUpOutlined, CaretDownOutlined, RightOutlined } from '@ant-design/icons';
+import type { TransformedCallvanReport } from 'model/callvan.model';
+import * as S from './CallvanCard.style';
+
+interface Props {
+  report: TransformedCallvanReport;
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  PENDING: '미처리',
+  CONFIRMED: '처리 완료',
+};
+
+const PROCESS_TYPE_OPTIONS = [
+  { label: '(1차) 주의 안내', value: 'WARNING' },
+  { label: '(2차) 콜밴 모집, 참여제한', value: 'TEMPORARY_RESTRICTION_14_DAYS' },
+  { label: '(3차) 콜밴 기능 영구 제한', value: 'PERMANENT_RESTRICTION' },
+  { label: '신고 반려', value: 'REJECT' },
+];
+
+const REASON_CODE_TYPE = {
+  NON_PAYMENT: '요금 미납',
+  NO_SHOW: '노쇼',
+  PROFANITY: '욕설',
+  OTHER: '기타',
+};
+
+export default function CallvanCard({ report }: Props) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const isPending = report.report_status === 'PENDING';
+
+  return (
+    <S.Container isPending={isPending}>
+      <S.Header>
+        <S.HeaderLeft>
+          <S.StatusBadge isPending={isPending}>
+            {STATUS_LABEL[report.report_status] ?? report.report_status}
+          </S.StatusBadge>
+        </S.HeaderLeft>
+        {!isPending && (
+          <S.ProcessText>
+            {`처리 : ${PROCESS_TYPE_OPTIONS.find((o) => o.value === report.process_type)?.label ?? report.process_type}`}
+          </S.ProcessText>
+        )}
+        {isPending && (
+          <S.StyledSelect
+            placeholder="처리 유형 선택"
+            options={PROCESS_TYPE_OPTIONS}
+            style={{ width: 180 }}
+          />
+        )}
+      </S.Header>
+      <S.InfoRow>
+        <S.InfoGroup>
+          <S.InfoItem>
+            <S.Label>피신고자 : </S.Label>
+            {`${report.name} (${report.nickname})`}
+          </S.InfoItem>
+          <S.InfoItem>{report.reported_at}</S.InfoItem>
+        </S.InfoGroup>
+      </S.InfoRow>
+      <S.InfoRow>
+        <S.InfoGroup>
+          <S.InfoItem>
+            <S.Label>사유 : </S.Label>
+            {report.reasons.map((r) => REASON_CODE_TYPE[r.reason_code as keyof typeof REASON_CODE_TYPE] ?? r.reason_code).join(', ')}
+          </S.InfoItem>
+          <S.InfoItem>
+            <S.Label>누적 </S.Label>
+            {`${report.accumulated_report_count}건`}
+            {isOpen && (
+              <Popover
+                open={isModalOpen}
+                onOpenChange={(v) => setIsModalOpen(v)}
+                trigger="click"
+                placement="right"
+                title={(
+                  <S.PopoverHeader>
+                    <span>누적 신고 내역</span>
+                    <S.PopoverClose onClick={() => setIsModalOpen(false)} />
+                  </S.PopoverHeader>
+                )}
+                content={(
+                  <div>
+                    {report.accumulated_reports.map((r, index) => (
+                      <div key={r.report_id} style={{ marginBottom: 12 }}>
+                        <div>
+                          {`${index + 1}. ${r.reported_at.slice(0, 10)}`}
+                        </div>
+                        <div style={{ paddingLeft: 16 }}>
+                          {`사유 : ${r.reasons.map((reason) => REASON_CODE_TYPE[reason.reason_code as keyof typeof REASON_CODE_TYPE] ?? reason.reason_code).join(', ')}`}
+                          &nbsp;&nbsp;
+                          {`처리 유형 : ${PROCESS_TYPE_OPTIONS.find((o) => o.value === r.process_type)?.label ?? '없음'}`}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              >
+                <RightOutlined style={{ cursor: 'pointer', marginLeft: 4 }} />
+              </Popover>
+            )}
+          </S.InfoItem>
+        </S.InfoGroup>
+      </S.InfoRow>
+      {isOpen && (
+        <>
+          <S.SectionTitle>신고 상황</S.SectionTitle>
+          <S.SectionContent>{report.description || '-'}</S.SectionContent>
+          <S.SectionTitle>첨부 이미지</S.SectionTitle>
+          {report.attachment_urls.length > 0 ? (
+            <S.ImageRow>
+              {report.attachment_urls.map((url) => (
+                <S.AttachImage key={url} src={url} alt="첨부 이미지" loading="lazy" />
+              ))}
+            </S.ImageRow>
+          ) : (
+            <S.SectionContent>없음</S.SectionContent>
+          )}
+        </>
+      )}
+      <S.ToggleButton type="button" onClick={() => setIsOpen((prev) => !prev)}>
+        {isOpen ? <CaretUpOutlined /> : <CaretDownOutlined />}
+      </S.ToggleButton>
+    </S.Container>
+  );
+}

--- a/src/pages/Services/Callvan/CallvanCard.tsx
+++ b/src/pages/Services/Callvan/CallvanCard.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import useBooleanState from 'utils/hooks/useBoolean';
 import { message, Modal, Popover } from 'antd';
 import { CaretUpOutlined, CaretDownOutlined, RightOutlined } from '@ant-design/icons';
 import type { CallvanParam, TransformedCallvanReport } from 'model/callvan.model';
@@ -38,16 +39,12 @@ const formatReason = (reason: { reason_code: string; custom_text: string }) => {
 };
 
 export default function CallvanCard({ report, param }: Props) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { value: isOpen, changeValue: toggleOpen } = useBooleanState(false);
+  const { value: isModalOpen, setTrue: openModal, setFalse: closeModal } = useBooleanState(false);
   const [selectedProcessType, setSelectedProcessType] = useState<string | null>(null);
   const isPending = report.report_status === 'PENDING';
 
   const { mutate: processCallvan, isPending: isProcessing } = useProcessCallvan(param);
-
-  const handleSelectChange = (value: string) => {
-    setSelectedProcessType(value);
-  };
 
   const handleConfirm = () => {
     if (!selectedProcessType) return;
@@ -79,19 +76,20 @@ export default function CallvanCard({ report, param }: Props) {
             {STATUS_LABEL[report.report_status] ?? report.report_status}
           </S.StatusBadge>
         </S.HeaderLeft>
-        {!isPending && (
-          <S.ProcessText>
-            {`처리 : ${PROCESS_TYPE_OPTIONS.find((o) => o.value === report.process_type)?.label ?? report.process_type}`}
-          </S.ProcessText>
-        )}
-        {isPending && (
-          <S.StyledSelect
-            placeholder="처리 유형 선택"
-            options={PROCESS_TYPE_OPTIONS}
-            value={selectedProcessType}
-            onChange={(value) => handleSelectChange(value as string)}
-          />
-        )}
+        {isPending
+          ? (
+            <S.StyledSelect
+              placeholder="처리 유형 선택"
+              options={PROCESS_TYPE_OPTIONS}
+              value={selectedProcessType}
+              onChange={setSelectedProcessType}
+            />
+          )
+          : (
+            <S.ProcessText>
+              {`처리 : ${PROCESS_TYPE_OPTIONS.find((o) => o.value === report.process_type)?.label ?? report.process_type}`}
+            </S.ProcessText>
+          )}
       </S.Header>
       <S.InfoRow>
         <S.InfoGroup>
@@ -116,13 +114,13 @@ export default function CallvanCard({ report, param }: Props) {
             {isOpen && (
               <Popover
                 open={isModalOpen}
-                onOpenChange={(v) => setIsModalOpen(v)}
+                onOpenChange={(v) => (v ? openModal() : closeModal())}
                 trigger="click"
                 placement="right"
                 title={(
                   <S.PopoverHeader>
                     <span>누적 신고 내역</span>
-                    <S.PopoverClose onClick={() => setIsModalOpen(false)} />
+                    <S.PopoverClose onClick={closeModal} />
                   </S.PopoverHeader>
                 )}
                 content={(
@@ -170,7 +168,7 @@ export default function CallvanCard({ report, param }: Props) {
           )}
         </>
       )}
-      <S.ToggleButton type="button" onClick={() => setIsOpen((prev) => !prev)}>
+      <S.ToggleButton type="button" onClick={toggleOpen}>
         {isOpen ? <CaretUpOutlined /> : <CaretDownOutlined />}
       </S.ToggleButton>
       <Modal

--- a/src/pages/Services/Callvan/CallvanCard.tsx
+++ b/src/pages/Services/Callvan/CallvanCard.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
-import { Popover } from 'antd';
+import { message, Modal, Popover } from 'antd';
 import { CaretUpOutlined, CaretDownOutlined, RightOutlined } from '@ant-design/icons';
-import type { TransformedCallvanReport } from 'model/callvan.model';
+import type { CallvanParam, TransformedCallvanReport } from 'model/callvan.model';
+import { useProcessCallvan } from 'queryFactory/callvanQueries';
 import * as S from './CallvanCard.style';
 
 interface Props {
   report: TransformedCallvanReport;
+  param: CallvanParam;
 }
 
 const STATUS_LABEL: Record<string, string> = {
@@ -27,10 +29,47 @@ const REASON_CODE_TYPE = {
   OTHER: '기타',
 };
 
-export default function CallvanCard({ report }: Props) {
+const formatReason = (reason: { reason_code: string; custom_text: string }) => {
+  const label = REASON_CODE_TYPE[reason.reason_code as keyof typeof REASON_CODE_TYPE]
+    ?? reason.reason_code;
+  return reason.reason_code === 'OTHER' && reason.custom_text
+    ? `${label}(${reason.custom_text})`
+    : label;
+};
+
+export default function CallvanCard({ report, param }: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedProcessType, setSelectedProcessType] = useState<string | null>(null);
   const isPending = report.report_status === 'PENDING';
+
+  const { mutate: processCallvan, isPending: isProcessing } = useProcessCallvan(param);
+
+  const handleSelectChange = (value: string) => {
+    setSelectedProcessType(value);
+  };
+
+  const handleConfirm = () => {
+    if (!selectedProcessType) return;
+    processCallvan(
+      { reportId: report.id, process_type: selectedProcessType },
+      {
+        onSuccess: () => {
+          message.success('처리가 완료되었습니다.');
+          setSelectedProcessType(null);
+        },
+        onError: (error: unknown) => {
+          type ApiError = { response?: { data?: { message?: string } } };
+          const msg = (error as ApiError)?.response?.data?.message;
+          message.error(msg ?? '처리 중 오류가 발생했습니다.');
+        },
+      },
+    );
+  };
+
+  const handleCancel = () => {
+    setSelectedProcessType(null);
+  };
 
   return (
     <S.Container isPending={isPending}>
@@ -49,7 +88,8 @@ export default function CallvanCard({ report }: Props) {
           <S.StyledSelect
             placeholder="처리 유형 선택"
             options={PROCESS_TYPE_OPTIONS}
-            style={{ width: 180 }}
+            value={selectedProcessType}
+            onChange={(value) => handleSelectChange(value as string)}
           />
         )}
       </S.Header>
@@ -59,14 +99,16 @@ export default function CallvanCard({ report }: Props) {
             <S.Label>피신고자 : </S.Label>
             {`${report.name} (${report.nickname})`}
           </S.InfoItem>
-          <S.InfoItem>{report.reported_at.slice(0, 10)}</S.InfoItem>
+          <S.InfoItem>
+            {`${report.reported_at.slice(0, 10)} ${report.reported_at.slice(11, 19)}`}
+          </S.InfoItem>
         </S.InfoGroup>
       </S.InfoRow>
       <S.InfoRow>
         <S.InfoGroup>
           <S.InfoItem>
             <S.Label>사유 : </S.Label>
-            {report.reasons.map((r) => REASON_CODE_TYPE[r.reason_code as keyof typeof REASON_CODE_TYPE] ?? r.reason_code).join(', ')}
+            {report.reasons.map(formatReason).join(', ')}
           </S.InfoItem>
           <S.InfoItem>
             <S.Label>누적 </S.Label>
@@ -91,7 +133,7 @@ export default function CallvanCard({ report }: Props) {
                           {`${index + 1}. ${r.reported_at.slice(0, 10)}`}
                         </div>
                         <div style={{ paddingLeft: 16 }}>
-                          {`사유 : ${r.reasons.map((reason) => REASON_CODE_TYPE[reason.reason_code as keyof typeof REASON_CODE_TYPE] ?? reason.reason_code).join(', ')}`}
+                          {`사유 : ${r.reasons.map(formatReason).join(', ')}`}
                           &nbsp;&nbsp;
                           {`처리 유형 : ${PROCESS_TYPE_OPTIONS.find((o) => o.value === r.process_type)?.label ?? '없음'}`}
                         </div>
@@ -114,7 +156,13 @@ export default function CallvanCard({ report }: Props) {
           {report.attachment_urls.length > 0 ? (
             <S.ImageRow>
               {report.attachment_urls.map((url) => (
-                <S.AttachImage key={url} src={url} alt="첨부 이미지" loading="lazy" />
+                <S.StyledImage
+                  key={url}
+                  src={url}
+                  alt="첨부이미지"
+                  width={120}
+                  height={120}
+                />
               ))}
             </S.ImageRow>
           ) : (
@@ -125,6 +173,17 @@ export default function CallvanCard({ report }: Props) {
       <S.ToggleButton type="button" onClick={() => setIsOpen((prev) => !prev)}>
         {isOpen ? <CaretUpOutlined /> : <CaretDownOutlined />}
       </S.ToggleButton>
+      <Modal
+        title="처리 유형 확인"
+        open={!!selectedProcessType}
+        onOk={handleConfirm}
+        onCancel={handleCancel}
+        okText="확인"
+        cancelText="취소"
+        confirmLoading={isProcessing}
+      >
+        {`"${PROCESS_TYPE_OPTIONS.find((o) => o.value === selectedProcessType)?.label}" 처리하시겠습니까?`}
+      </Modal>
     </S.Container>
   );
 }

--- a/src/pages/Services/Callvan/CallvanCard.tsx
+++ b/src/pages/Services/Callvan/CallvanCard.tsx
@@ -59,7 +59,7 @@ export default function CallvanCard({ report }: Props) {
             <S.Label>피신고자 : </S.Label>
             {`${report.name} (${report.nickname})`}
           </S.InfoItem>
-          <S.InfoItem>{report.reported_at}</S.InfoItem>
+          <S.InfoItem>{report.reported_at.slice(0, 10)}</S.InfoItem>
         </S.InfoGroup>
       </S.InfoRow>
       <S.InfoRow>

--- a/src/pages/Services/Callvan/CallvanList.style.tsx
+++ b/src/pages/Services/Callvan/CallvanList.style.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+import { Checkbox } from 'antd';
+
+export * from 'styles/List.style';
+
+export const StyledCheckbox = styled(Checkbox)`
+  margin: 12px 0px 0px 12px;
+`;
+export const DataContainer = styled.div`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  gap: 15px;
+  width: 100%;
+  margin-bottom: 30px;
+  margin-left: 20px;
+`;

--- a/src/pages/Services/Callvan/CallvanList.tsx
+++ b/src/pages/Services/Callvan/CallvanList.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { Pagination, Skeleton } from 'antd';
+import { useQuery } from '@tanstack/react-query';
+import callvanQueries from 'queryFactory/callvanQueries';
+import CallvanCard from './CallvanCard';
+import * as S from './CallvanList.style';
+
+const LIMIT = 10;
+
+export default function CallvanList() {
+  const [page, setPage] = useState(1);
+  const [onlyPending, setOnlyPending] = useState(false);
+
+  const { data, isLoading } = useQuery(callvanQueries.callvanList({
+    page,
+    limit: LIMIT,
+    only_pending: onlyPending,
+  }));
+
+  const handleFilterChange = () => {
+    setOnlyPending((prev) => !prev);
+    setPage(1);
+  };
+
+  return (
+    <S.Container>
+      <S.Heading>콜밴팟 사용자 관리</S.Heading>
+      {isLoading ? [1, 2, 3, 4, 5].map((key) => <Skeleton key={key} active />) : (
+        <>
+          <S.StyledCheckbox
+            checked={onlyPending}
+            onChange={handleFilterChange}
+          >
+            미처리 신고만 모아보기
+          </S.StyledCheckbox>
+          <S.DataContainer>
+            {data && data.reports.map((report) => (
+              <CallvanCard
+                report={report}
+                key={report.id}
+              />
+            ))}
+            {data && (
+              <Pagination
+                total={data.total_page * LIMIT}
+                current={page}
+                onChange={(num) => setPage(num)}
+                showSizeChanger={false}
+              />
+            )}
+          </S.DataContainer>
+        </>
+      )}
+    </S.Container>
+  );
+}

--- a/src/pages/Services/Callvan/CallvanList.tsx
+++ b/src/pages/Services/Callvan/CallvanList.tsx
@@ -38,6 +38,7 @@ export default function CallvanList() {
               <CallvanCard
                 report={report}
                 key={report.id}
+                param={{ page, limit: LIMIT, only_pending: onlyPending }}
               />
             ))}
             {data && (

--- a/src/pages/Services/Callvan/CallvanList.tsx
+++ b/src/pages/Services/Callvan/CallvanList.tsx
@@ -43,7 +43,7 @@ export default function CallvanList() {
             ))}
             {data && (
               <Pagination
-                total={data.total_page * LIMIT}
+                total={data.total_count}
                 current={page}
                 onChange={(num) => setPage(num)}
                 showSizeChanger={false}

--- a/src/queryFactory/callvanQueries.ts
+++ b/src/queryFactory/callvanQueries.ts
@@ -7,9 +7,9 @@ import type {
 } from 'model/callvan.model';
 
 const callvanQueries = {
-  allkeys: () => ['callvan'],
+  allKeys: () => ['callvan'],
 
-  callvanListKeys: (param: CallvanParam) => [...callvanQueries.allkeys(), param],
+  callvanListKeys: (param: CallvanParam) => [...callvanQueries.allKeys(), param],
   callvanList: (param: CallvanParam) => queryOptions({
     queryKey: callvanQueries.callvanListKeys(param),
     queryFn: () => getCallvanList(param),
@@ -27,7 +27,7 @@ const callvanQueries = {
         description: report.description,
         attachment_urls: report.attachment_urls,
       }));
-      return { reports, total_page: data.total_page };
+      return { reports, total_page: data.total_page, total_count: data.total_count };
     },
   }),
 };

--- a/src/queryFactory/callvanQueries.ts
+++ b/src/queryFactory/callvanQueries.ts
@@ -1,0 +1,35 @@
+import { queryOptions } from '@tanstack/react-query';
+import { getCallvanList } from 'api/callvan';
+import type {
+  CallvanParam,
+  CallvanListResponse,
+  TransformedCallvanListResponse,
+} from 'model/callvan.model';
+
+const callvanQueries = {
+  allkeys: () => ['callvan'],
+
+  callvanListKeys: (param: CallvanParam) => [...callvanQueries.allkeys(), param],
+  callvanList: (param: CallvanParam) => queryOptions({
+    queryKey: callvanQueries.callvanListKeys(param),
+    queryFn: () => getCallvanList(param),
+    select: (data: CallvanListResponse): TransformedCallvanListResponse => {
+      const reports = data.reports.map((report) => ({
+        id: report.report_id,
+        report_status: report.report_status,
+        name: report.reported_user.name,
+        nickname: report.reported_user.nickname,
+        reported_at: report.reported_at,
+        accumulated_report_count: report.accumulated_report_count,
+        accumulated_reports: report.accumulated_reports,
+        process_type: report.process_type,
+        reasons: report.reasons,
+        description: report.description,
+        attachment_urls: report.attachment_urls,
+      }));
+      return { reports, total_page: data.total_page };
+    },
+  }),
+};
+
+export default callvanQueries;

--- a/src/queryFactory/callvanQueries.ts
+++ b/src/queryFactory/callvanQueries.ts
@@ -1,5 +1,5 @@
-import { queryOptions } from '@tanstack/react-query';
-import { getCallvanList } from 'api/callvan';
+import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
+import { getCallvanList, postCallvanReports } from 'api/callvan';
 import type {
   CallvanParam,
   CallvanListResponse,
@@ -30,6 +30,16 @@ const callvanQueries = {
       return { reports, total_page: data.total_page };
     },
   }),
+};
+
+export const useProcessCallvan = (param: CallvanParam) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: postCallvanReports,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: callvanQueries.callvanListKeys(param) });
+    },
+  });
 };
 
 export default callvanQueries;


### PR DESCRIPTION
## What is this PR? 🔍

- 기능 : 콜밴 알림 UI 추가, 사용자 신고처리 및 시간 표시와 사진 확대 기능 추가
- issue : #126
 
## Changes 📝
- 콜밴팟 관리에서 신고가 접수된 사용자를 처리하는 화면을 구성했습니다. 
-**콜밴팟 사용자 관리 페이지 추가**: 코인 서비스 sideNav에  콜밴팟 사용자관리 항목 추가
-**신고목록 조회**: 신고가 접수된 사용자들을 조회
-**미처리 신고 모아보기**: 아직 처리가 완료되지 않은 신고 조회

신고가 접수된 사용자들을 처리 유형에 따라 처리하는 기능을 추가했습니다.
- **신고된 사용자 처리 추가**: 처리 유형을 선택하고 결과를 서버로 전송
- **처리완료시 표시**: 처리가 완료된 신고들은 색깔변경 후 처리완료 표시

시간표시 및 신고사유 표시 수정
- **시간표시 추가**: 신고 날짜 표시에 시간 추가
- **custom text 추가**신고사유가 OTHERS일때, custom text 표시

사진 확대 기능 추가
- **사진 확대 기능**: 첨부된 이미지를 클릭하면 확대 기능 추가

**구현 상세**
  - GetCallvanList API, postCallvanReports  추가
  - reports_status 여부에 따른 CallvanCard 스타일 변화
  - Popover을 통한 누적 신고 내역 확인
  - 처리 유형을 선택하면 선택 확인 모달 보여주기
  - 처리가 완료되면 처리 유형 표시

## ScreenShot 📷
<img width="1221" height="908" alt="image" src="https://github.com/user-attachments/assets/b95afd75-e3a6-4530-ad63-8c281c7f0688" />
<img width="1162" height="911" alt="콜렌팟 사용자 관리" src="https://github.com/user-attachments/assets/5458ee73-7755-40b5-a74f-65d095e7fa8d" />
<img width="955" height="539" alt="콜밴팟 사용자 관리" src="https://github.com/user-attachments/assets/df34b026-1b22-40b5-95cd-373d565b4ef3" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a "Callvan" user management area with its own navigation entry and route.
  * Paginated list of Callvan reports with expandable cards showing status, reporter info, reasons, attachments, and accumulated reports.
  * Filter to view only pending reports, in-card processing actions with confirmation modal, and success/error feedback.

* **Style**
  * New presentational styles for the Callvan list and report cards for improved layout and visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->